### PR TITLE
Create transceivers on set_remote_description

### DIFF
--- a/examples/example.exs
+++ b/examples/example.exs
@@ -31,7 +31,6 @@ defmodule Peer do
         Process.send_after(self(), :ws_ping, 1000)
 
         {:ok, pc} = PeerConnection.start_link(
-          bundle_policy: :max_bundle,
           ice_servers: @ice_servers
         )
 

--- a/lib/ex_webrtc/media_stream_track.ex
+++ b/lib/ex_webrtc/media_stream_track.ex
@@ -1,0 +1,23 @@
+defmodule ExWebRTC.MediaStreamTrack do
+  @moduledoc """
+  MediaStreamTrack
+  """
+
+  @type t() :: %__MODULE__{
+          kind: :audio | :video,
+          id: integer(),
+          mid: String.t()
+        }
+
+  @enforce_keys [:id, :kind]
+  defstruct @enforce_keys ++ [:mid]
+
+  def from_transceiver(tr) do
+    %__MODULE__{kind: tr.kind, id: generate_id(), mid: tr.mid}
+  end
+
+  defp generate_id() do
+    <<id::12*8>> = :crypto.strong_rand_bytes(12)
+    id
+  end
+end

--- a/lib/ex_webrtc/peer_connection/configuration.ex
+++ b/lib/ex_webrtc/peer_connection/configuration.ex
@@ -33,7 +33,7 @@ defmodule ExWebRTC.PeerConnection.Configuration do
           rtcp_mux_policy: rtcp_mux_policy()
         }
 
-  defstruct bundle_policy: :balanced,
+  defstruct bundle_policy: :max_bundle,
             certificates: nil,
             ice_candidate_pool_size: 0,
             ice_servers: [],

--- a/lib/ex_webrtc/rtp_transceiver.ex
+++ b/lib/ex_webrtc/rtp_transceiver.ex
@@ -1,0 +1,48 @@
+defmodule ExWebRTC.RTPTransceiver do
+  @moduledoc """
+  RTPTransceiver
+  """
+
+  @type t() :: %__MODULE__{
+          mid: String.t(),
+          direction: :sendonly | :recvonly | :sendrecv | :inactive | :stopped,
+          kind: :audio | :video
+        }
+
+  @enforce_keys [:mid, :direction, :kind]
+  defstruct @enforce_keys
+
+  @doc false
+  def find_by_mid(transceivers, mid) do
+    transceivers
+    |> Enum.with_index(fn tr, idx -> {idx, tr} end)
+    |> Enum.find(fn {_idx, tr} -> tr.mid == mid end)
+  end
+
+  # searches for transceiver for a given mline
+  # if it exists, updates its configuration
+  # if it doesn't exist, creats a new one
+  # returns list of updated transceivers
+  @doc false
+  def update_or_create(transceivers, mid, mline) do
+    case find_by_mid(transceivers, mid) do
+      {idx, %__MODULE__{} = tr} ->
+        case update(tr, mline) do
+          {:ok, tr} -> List.replace_at(transceivers, idx, tr)
+          {:error, :remove} -> List.delete_at(transceivers, idx)
+        end
+
+      nil ->
+        transceivers ++ [%__MODULE__{mid: mid, direction: :recvonly, kind: mline.type}]
+    end
+  end
+
+  defp update(transceiver, mline) do
+    # if there is no direction, the default is sendrecv
+    # see RFC 3264, sec. 6.1  
+    case ExWebRTC.Utils.get_media_direction(mline) || :sendrecv do
+      :inactive -> {:error, :remove}
+      other_direction -> {:ok, %__MODULE__{transceiver | direction: other_direction}}
+    end
+  end
+end

--- a/lib/ex_webrtc/rtp_transceiver.ex
+++ b/lib/ex_webrtc/rtp_transceiver.ex
@@ -27,22 +27,12 @@ defmodule ExWebRTC.RTPTransceiver do
   def update_or_create(transceivers, mid, mline) do
     case find_by_mid(transceivers, mid) do
       {idx, %__MODULE__{} = tr} ->
-        case update(tr, mline) do
-          {:ok, tr} -> List.replace_at(transceivers, idx, tr)
-          {:error, :remove} -> List.delete_at(transceivers, idx)
-        end
+        List.replace_at(transceivers, idx, update(tr, mline))
 
       nil ->
         transceivers ++ [%__MODULE__{mid: mid, direction: :recvonly, kind: mline.type}]
     end
   end
 
-  defp update(transceiver, mline) do
-    # if there is no direction, the default is sendrecv
-    # see RFC 3264, sec. 6.1  
-    case ExWebRTC.Utils.get_media_direction(mline) || :sendrecv do
-      :inactive -> {:error, :remove}
-      other_direction -> {:ok, %__MODULE__{transceiver | direction: other_direction}}
-    end
-  end
+  defp update(transceiver, _mline), do: transceiver
 end

--- a/lib/ex_webrtc/utils.ex
+++ b/lib/ex_webrtc/utils.ex
@@ -7,4 +7,10 @@ defmodule ExWebRTC.Utils do
     |> :binary.bin_to_list()
     |> Enum.map_join(":", &Base.encode16(<<&1>>))
   end
+
+  def get_media_direction(media) do
+    Enum.find(media.attributes, fn attr ->
+      attr in [:sendrecv, :sendonly, :recvonly, :inactive]
+    end)
+  end
 end

--- a/test/peer_connection_test.exs
+++ b/test/peer_connection_test.exs
@@ -1,0 +1,98 @@
+defmodule ExWebRTC.PeerConnectionTest do
+  use ExUnit.Case, async: true
+
+  alias ExWebRTC.{MediaStreamTrack, PeerConnection, SessionDescription}
+
+  @single_audio_offer """
+  v=0
+  o=- 6788894006044524728 2 IN IP4 127.0.0.1
+  s=-
+  t=0 0
+  a=group:BUNDLE 0
+  a=extmap-allow-mixed
+  a=msid-semantic: WMS
+  m=audio 9 UDP/TLS/RTP/SAVPF 111
+  c=IN IP4 0.0.0.0
+  a=rtcp:9 IN IP4 0.0.0.0
+  a=ice-ufrag:cDua
+  a=ice-pwd:v9SCmZHxJWtgpyzn8Ts1puT6
+  a=ice-options:trickle
+  a=fingerprint:sha-256 11:35:68:66:A4:C3:C0:AA:37:4E:0F:97:D7:9F:76:11:08:DB:56:DA:4B:83:77:50:9A:D2:71:8D:2A:A8:E3:07
+  a=setup:actpass
+  a=mid:0
+  a=sendrecv
+  a=msid:- 54f0751b-086f-433c-af40-79c179182423
+  a=rtcp-mux
+  a=rtpmap:111 opus/48000/2
+  a=rtcp-fb:111 transport-cc
+  a=fmtp:111 minptime=10;useinbandfec=1
+  a=ssrc:1463342914 cname:poWwjNZ4I2ZZgzY7
+  a=ssrc:1463342914 msid:- 54f0751b-086f-433c-af40-79c179182423
+  """
+
+  @audio_video_offer """
+  v=0
+  o=- 3253533641493747086 5 IN IP4 127.0.0.1
+  s=-
+  t=0 0
+  a=group:BUNDLE 0 1
+  a=extmap-allow-mixed
+  a=msid-semantic: WMS
+  m=audio 9 UDP/TLS/RTP/SAVPF 111
+  c=IN IP4 0.0.0.0
+  a=rtcp:9 IN IP4 0.0.0.0
+  a=ice-ufrag:SOct
+  a=ice-pwd:k9PRXt7zT32ADt/juUpt4Gx3
+  a=ice-options:trickle
+  a=fingerprint:sha-256 45:B5:2D:3A:DA:29:93:27:B6:59:F1:5B:77:62:F5:C2:CE:16:8B:12:C7:B8:34:EF:C0:12:45:17:D0:1A:E6:F4
+  a=setup:actpass
+  a=mid:0
+  a=sendrecv
+  a=msid:- 0970fb0b-4750-4302-902e-70d2e403ad0d
+  a=rtcp-mux
+  a=rtpmap:111 opus/48000/2
+  a=rtcp-fb:111 transport-cc
+  a=fmtp:111 minptime=10;useinbandfec=1
+  a=ssrc:560549895 cname:QQJypppcjR+gR484
+  a=ssrc:560549895 msid:- 0970fb0b-4750-4302-902e-70d2e403ad0d
+  m=video 9 UDP/TLS/RTP/SAVPF 96
+  c=IN IP4 0.0.0.0
+  a=rtcp:9 IN IP4 0.0.0.0
+  a=ice-ufrag:SOct
+  a=ice-pwd:k9PRXt7zT32ADt/juUpt4Gx3
+  a=ice-options:trickle
+  a=fingerprint:sha-256 45:B5:2D:3A:DA:29:93:27:B6:59:F1:5B:77:62:F5:C2:CE:16:8B:12:C7:B8:34:EF:C0:12:45:17:D0:1A:E6:F4
+  a=setup:actpass
+  a=mid:1
+  a=sendrecv
+  a=msid:- 1259ea70-c6b7-445a-9c20-49cec7433ccb
+  a=rtcp-mux
+  a=rtcp-rsize
+  a=rtpmap:96 VP8/90000
+  a=rtcp-fb:96 goog-remb
+  a=rtcp-fb:96 transport-cc
+  a=rtcp-fb:96 ccm fir
+  a=rtcp-fb:96 nack
+  a=rtcp-fb:96 nack pli
+  a=ssrc-group:FID 381060598 184440407
+  a=ssrc:381060598 cname:QQJypppcjR+gR484
+  a=ssrc:381060598 msid:- 1259ea70-c6b7-445a-9c20-49cec7433ccb
+  a=ssrc:184440407 cname:QQJypppcjR+gR484
+  a=ssrc:184440407 msid:- 1259ea70-c6b7-445a-9c20-49cec7433ccb
+  """
+
+  test "transceivers" do
+    {:ok, pc} = PeerConnection.start_link()
+
+    offer = %SessionDescription{type: :offer, sdp: @single_audio_offer}
+    :ok = PeerConnection.set_remote_description(pc, offer)
+
+    assert_receive {:ex_webrtc, ^pc, {:track, %MediaStreamTrack{mid: "0", kind: :audio}}}
+
+    offer = %SessionDescription{type: :offer, sdp: @audio_video_offer}
+    :ok = PeerConnection.set_remote_description(pc, offer)
+
+    assert_receive {:ex_webrtc, ^pc, {:track, %MediaStreamTrack{mid: "1", kind: :video}}}
+    refute_receive {:ex_webrtc, ^pc, {:track, %MediaStreamTrack{}}}
+  end
+end


### PR DESCRIPTION
Definitely not perfect and for sure bugged but maybe this can be a base for further work.

The idea is that we iterate over mlines in SDP, we try to find a transceiver for a given mline, if it exists we potentially update its configuraiton. If it doesn't exist we create a new one. At the end we compare previous transceivers with new transceivers and try to find new MediaStreamTracks