### PR TITLE
Configure codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Lint and test
+name: CI 
 
 on: push
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  require_ci_to_pass: false
+
+comment:
+  layout: "header, diff, files, footer"
+  behavior: default
+
+github_checks:
+  annotations: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,5 +5,14 @@ comment:
   layout: "header, diff, files, footer"
   behavior: default
 
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
 github_checks:
   annotations: false


### PR DESCRIPTION
* disabled github notifications that something is not covered by tests
* we don't need to wait for other checks to run codecov
* changed the layout of codecov comment so we see more info. Behavior `default` means that the comment is updated when new commits appear
* disabled coverage threshold