### PR TITLE
Extend Ogg examples

### DIFF
--- a/examples/save_to_file/.gitignore
+++ b/examples/save_to_file/.gitignore
@@ -1,1 +1,2 @@
 output.ivf
+output.ogg

--- a/examples/save_to_file/.gitignore
+++ b/examples/save_to_file/.gitignore
@@ -1,2 +1,2 @@
-output.ivf
-output.ogg
+video.ivf
+audio.ogg

--- a/examples/save_to_file/README.md
+++ b/examples/save_to_file/README.md
@@ -5,3 +5,9 @@ Receive video from a browser and save it to a file.
 1. Start `ex_ice/signalling_server` with `mix run --no-halt`
 2. Run `elixir example.exs`
 3. Visit `example.html` in your browser e.g. `file:///home/Repos/elixir-webrtc/ex_webrtc/examples/save_to_file/example.html`
+4. Press `Start` button to start the connection, then `Stop` button to stop recording.
+5. Video and audio have been saved to `video.ivf` and `audio.ogg` files. Play it with
+
+```console
+ffplay audio.ogg
+```

--- a/examples/save_to_file/README.md
+++ b/examples/save_to_file/README.md
@@ -10,4 +10,5 @@ Receive video from a browser and save it to a file.
 
 ```console
 ffplay audio.ogg
+ffplay video.ivf
 ```

--- a/examples/save_to_file/example.exs
+++ b/examples/save_to_file/example.exs
@@ -16,7 +16,7 @@ defmodule Peer do
     RTPCodecParameters
   }
 
-  alias ExWebRTC.RTP.VP8Depayloader
+  alias ExWebRTC.RTP.{OpusDepayloader, VP8Depayloader}
   alias ExWebRTC.Media.{IVFFrame, IVFWriter, OggWriter}
 
   @ice_servers [
@@ -206,7 +206,8 @@ defmodule Peer do
   end
 
   defp handle_webrtc_message({:rtp, id, packet}, %{audio_track_id: id} = state) do
-    {:ok, ogg_writer} = OggWriter.write_packet(state.ogg_writer, packet.payload)
+    opus_packet = OpusDepayloader.depayload(packet)
+    {:ok, ogg_writer} = OggWriter.write_packet(state.ogg_writer, opus_packet)
     %{state | ogg_writer: ogg_writer}
   end
 

--- a/examples/save_to_file/example.html
+++ b/examples/save_to_file/example.html
@@ -12,6 +12,7 @@
     <main>
         <h1>Elixir WebRTC Save to File Example</h1>
     </main>
+    <button id="button" >Start</button>
     <video id="videoPlayer" autoplay muted></video>
     <script src="example.js"></script>
 </body>

--- a/examples/save_to_file/example.js
+++ b/examples/save_to_file/example.js
@@ -17,6 +17,7 @@ const start_connection = async (ws) => {
     };
 
     const localStream = await navigator.mediaDevices.getUserMedia({
+        audio: true,
         video: {
             width: { ideal: 640 },
             height: { ideal: 480 },

--- a/examples/save_to_file/example.js
+++ b/examples/save_to_file/example.js
@@ -50,6 +50,13 @@ const start_connection = async (ws) => {
     ws.send(JSON.stringify(desc))
 };
 
-const ws = new WebSocket("ws://127.0.0.1:4000/websocket");
-ws.onclose = event => console.log("WebSocket was closed", event);
-ws.onopen = _ => start_connection(ws);
+const button = document.getElementById("button");
+let ws;
+button.onclick = () => {
+    ws = new WebSocket("ws://127.0.0.1:4000/websocket");
+    ws.onclose = event => console.log("WebSocket was closed", event);
+    ws.onopen = _ => start_connection(ws);
+
+    button.textContent = "Stop";
+    button.onclick = () => ws.close();
+}

--- a/lib/ex_webrtc/rtp/opus_depayloader.ex
+++ b/lib/ex_webrtc/rtp/opus_depayloader.ex
@@ -1,0 +1,13 @@
+defmodule ExWebRTC.RTP.OpusDepayloader do
+  @moduledoc """
+  Desapsualtes Opus audio out of RTP packet.
+  """
+
+  alias ExRTP.Packet
+
+  @doc """
+  Takes Opus packet out of an RTP packet.
+  """
+  @spec depayload(Packet.t()) :: binary()
+  def depayload(%Packet{payload: payload}), do: payload
+end

--- a/lib/ex_webrtc/rtp/opus_depayloader.ex
+++ b/lib/ex_webrtc/rtp/opus_depayloader.ex
@@ -1,6 +1,6 @@
 defmodule ExWebRTC.RTP.OpusDepayloader do
   @moduledoc """
-  Desapsualtes Opus audio out of RTP packet.
+  Decapsualtes Opus audio out of RTP packet.
   """
 
   alias ExRTP.Packet


### PR DESCRIPTION
- adds Ogg `save_to_file` example,
- makes variable naming in examples consistent,
- adds Opus depayloader (for the sake of consistency)