### PR TITLE
Handle ExDTLS errors

### DIFF
--- a/examples/echo/example.exs
+++ b/examples/echo/example.exs
@@ -12,16 +12,15 @@ defmodule Peer do
     ICECandidate,
     PeerConnection,
     MediaStreamTrack,
-    SessionDescription,
-    RTPTransceiver
+    SessionDescription
   }
 
   @ice_servers [
     %{urls: "stun:stun.l.google.com:19302"}
   ]
 
-  def start_link() do
-    GenServer.start_link(__MODULE__, nil)
+  def start() do
+    GenServer.start(__MODULE__, nil)
   end
 
   @impl true
@@ -189,12 +188,12 @@ defmodule Peer do
   end
 end
 
-{:ok, pid} = Peer.start_link()
+{:ok, pid} = Peer.start()
 ref = Process.monitor(pid)
 
 receive do
-  {:DOWN, ^ref, _, _, _} ->
-    Logger.info("Peer process closed. Exiting")
+  {:DOWN, ^ref, _, _, reason} ->
+    Logger.info("Peer process closed, reason: #{inspect(reason)}. Exiting")
 
   other ->
     Logger.warning("Unexpected msg. Exiting. Msg: #{inspect(other)}")

--- a/examples/save_to_file/example.html
+++ b/examples/save_to_file/example.html
@@ -12,7 +12,7 @@
     <main>
         <h1>Elixir WebRTC Save to File Example</h1>
     </main>
-    <button id="button" >Start</button>
+    <button id="button">Start</button>
     <video id="videoPlayer" autoplay muted></video>
     <script src="example.js"></script>
 </body>

--- a/examples/send_from_file/example.exs
+++ b/examples/send_from_file/example.exs
@@ -29,8 +29,8 @@ defmodule Peer do
     %{urls: "stun:stun.l.google.com:19302"}
   ]
 
-  def start_link() do
-    GenServer.start_link(__MODULE__, nil)
+  def start() do
+    GenServer.start(__MODULE__, nil)
   end
 
   @impl true
@@ -269,12 +269,12 @@ defmodule Peer do
   end
 end
 
-{:ok, pid} = Peer.start_link()
+{:ok, pid} = Peer.start()
 ref = Process.monitor(pid)
 
 receive do
-  {:DOWN, ^ref, _, _, _} ->
-    Logger.info("Peer process closed. Exiting")
+  {:DOWN, ^ref, _, _, reason} ->
+    Logger.info("Peer process closed, reason: #{inspect(reason)}. Exiting")
 
   other ->
     Logger.warning("Unexpected msg. Exiting. Msg: #{inspect(other)}")


### PR DESCRIPTION
When we notice ExDTLS error, DTLSTransport will stop itself and because it is linked with PeerConnection and PeerConnection is linked with ICETransport, everything will stop too