### PR TITLE
Fix bug with choosing transceiver for remote m-line

### DIFF
--- a/lib/ex_webrtc/rtp_sender.ex
+++ b/lib/ex_webrtc/rtp_sender.ex
@@ -52,14 +52,15 @@ defmodule ExWebRTC.RTPSender do
   end
 
   @doc false
-  @spec update(t(), RTPCodecParameters.t(), [Extmap.t()]) :: t()
-  def update(sender, codec, rtp_hdr_exts) do
+  @spec update(t(), String.t(), RTPCodecParameters.t(), [Extmap.t()]) :: t()
+  def update(sender, mid, codec, rtp_hdr_exts) do
+    if sender.mid != nil and mid != sender.mid, do: raise(ArgumentError)
     # convert to a map to be able to find extension id using extension uri
     rtp_hdr_exts = Map.new(rtp_hdr_exts, fn extmap -> {extmap.uri, extmap} end)
     # TODO: handle cases when codec == nil (no valid codecs after negotiation)
     pt = if codec != nil, do: codec.payload_type, else: nil
 
-    %__MODULE__{sender | codec: codec, rtp_hdr_exts: rtp_hdr_exts, pt: pt}
+    %__MODULE__{sender | mid: mid, codec: codec, rtp_hdr_exts: rtp_hdr_exts, pt: pt}
   end
 
   # Prepares packet for sending i.e.:

--- a/test/ex_webrtc/peer_connection_test.exs
+++ b/test/ex_webrtc/peer_connection_test.exs
@@ -762,6 +762,27 @@ defmodule ExWebRTC.PeerConnectionTest do
       test_send_data(pc1, pc2, track1, track2)
     end
 
+    test "using one negotiation, with tracks added beforehand" do
+      {:ok, pc1} = PeerConnection.start_link()
+      {:ok, pc2} = PeerConnection.start_link()
+
+      track1 = MediaStreamTrack.new(:audio)
+      track2 = MediaStreamTrack.new(:audio)
+
+      {:ok, _sender} = PeerConnection.add_track(pc1, track1)
+      {:ok, _sender} = PeerConnection.add_track(pc2, track2)
+
+      {:ok, offer} = PeerConnection.create_offer(pc1)
+      :ok = PeerConnection.set_local_description(pc1, offer)
+      :ok = PeerConnection.set_remote_description(pc2, offer)
+
+      {:ok, answer} = PeerConnection.create_answer(pc2)
+      :ok = PeerConnection.set_local_description(pc2, answer)
+      :ok = PeerConnection.set_remote_description(pc1, answer)
+
+      test_send_data(pc1, pc2, track1, track2)
+    end
+
     test "using renegotiation" do
       # setup track pc1 -> pc2
       {:ok, pc1} = PeerConnection.start_link()


### PR DESCRIPTION
New m-line in a remote offer always resulted in our `PeerConnection` creating new transceiver, when it should firstly look for a transceiver that is "associable" (see RFC 8829, sec. 5.10).

This PR fixes the issue.