### PR TITLE
Fix issue with rejecting non-matching FMTP

### DIFF
--- a/examples/echo/lib/echo/peer_handler.ex
+++ b/examples/echo/lib/echo/peer_handler.ex
@@ -19,10 +19,7 @@ defmodule Echo.PeerHandler do
     %RTPCodecParameters{
       payload_type: 96,
       mime_type: "video/VP8",
-      clock_rate: 90_000,
-      channels: nil,
-      sdp_fmtp_line: nil,
-      rtcp_fbs: []
+      clock_rate: 90_000
     }
   ]
 
@@ -31,8 +28,7 @@ defmodule Echo.PeerHandler do
       payload_type: 111,
       mime_type: "audio/opus",
       clock_rate: 48_000,
-      channels: 2,
-      sdp_fmtp_line: %ExSDP.Attribute.FMTP{pt: 111, minptime: 10, useinbandfec: true}
+      channels: 2
     }
   ]
 

--- a/examples/save_to_file/lib/save_to_file/peer_handler.ex
+++ b/examples/save_to_file/lib/save_to_file/peer_handler.ex
@@ -25,10 +25,7 @@ defmodule SaveToFile.PeerHandler do
     %RTPCodecParameters{
       payload_type: 96,
       mime_type: "video/VP8",
-      clock_rate: 90_000,
-      channels: nil,
-      sdp_fmtp_line: nil,
-      rtcp_fbs: []
+      clock_rate: 90_000
     }
   ]
 
@@ -37,8 +34,7 @@ defmodule SaveToFile.PeerHandler do
       payload_type: 111,
       mime_type: "audio/opus",
       clock_rate: 48_000,
-      channels: 2,
-      sdp_fmtp_line: %ExSDP.Attribute.FMTP{pt: 111, minptime: 10, useinbandfec: true}
+      channels: 2
     }
   ]
 

--- a/examples/send_from_file/lib/send_from_file/peer_handler.ex
+++ b/examples/send_from_file/lib/send_from_file/peer_handler.ex
@@ -29,10 +29,7 @@ defmodule SendFromFile.PeerHandler do
     %RTPCodecParameters{
       payload_type: 96,
       mime_type: "video/VP8",
-      clock_rate: 90_000,
-      channels: nil,
-      sdp_fmtp_line: nil,
-      rtcp_fbs: []
+      clock_rate: 90_000
     }
   ]
 
@@ -41,8 +38,7 @@ defmodule SendFromFile.PeerHandler do
       payload_type: 111,
       mime_type: "audio/opus",
       clock_rate: 48_000,
-      channels: 2,
-      sdp_fmtp_line: %ExSDP.Attribute.FMTP{pt: 111, minptime: 10, useinbandfec: true}
+      channels: 2
     }
   ]
 


### PR DESCRIPTION
As of now, when negotiation a codec, the `fmtp` attribute must much exactly, which might be an issue. This PR makes it possible to accept codecs with `fmtp` that does not match exactly to what's allowed in `video_codecs` or `audio_codecs`.