### PR TITLE
Call end_of_candidates on receiving an empty ICE candidate

### DIFF
--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -392,6 +392,12 @@ defmodule ExWebRTC.PeerConnection do
   end
 
   @impl true
+  def handle_call({:add_ice_candidate, %{candidate: ""}}, _from, state) do
+    :ok = state.ice_transport.end_of_candidates(state.ice_pid)
+    {:reply, :ok, state}
+  end
+
+  @impl true
   def handle_call({:add_ice_candidate, candidate}, _from, state) do
     with "candidate:" <> attr <- candidate.candidate do
       state.ice_transport.add_remote_candidate(state.ice_pid, attr)


### PR DESCRIPTION
Looks like Firefox won't start sending data until there is at least one nominated pair.
Even when it has succeeded pair.

I ran FF with `MOZ_LOG=webrtc_trace:5 firefox` and in `about:firefox` there is:

```
ICE-PEER(PC:{c24206e8-75db-4355-a73b-de9a9828c09c} 1707254636988657 (id=6442450946 url=http://127.0.0.1:8829/index.html):default)/CAND-PAIR(kWR0): setting pair to state SUCCEEDED: ...
```


In our ICE implementation, we only nominate after the remote side has indicated that there won't be any new remote candidates - we follow RFC 8445.

IIRC, most of implementations rely on aggressive nomination described in RFC 5245.

Our implementation should be compatible both with 8445 and 5245 but apparently I might have missed something.

Calling end_of_candidates solves the problem but this needs further investigation - see elixir-webrtc/ex_ice#19