### PR TITLE
Allow `MediaStreamTrack.t()` as a parameter to `send_rtp/3` 

### DIFF
--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -725,7 +725,7 @@ defmodule ExWebRTC.PeerConnection do
   end
 
   @impl true
-  def handle_cast({:send_rtp, track_id, packet}, state) when is_integer(track_id) do
+  def handle_cast({:send_rtp, track_id, packet}, state) do
     # TODO: iterating over transceivers is not optimal
     # but this is, most likely, going to be refactored anyways
     {transceiver, idx} =

--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -719,7 +719,7 @@ defmodule ExWebRTC.PeerConnection do
   end
 
   @impl true
-  def handle_cast({:send_rtp, %MediaStreamTrack{id: track_id}, packet}, state) do
+  def handle_cast({:send_rtp, track_id, packet}, state) when is_integer(track_id) do
     # TODO: iterating over transceivers is not optimal
     # but this is, most likely, going to be refactored anyways
     {transceiver, idx} =

--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -168,10 +168,13 @@ defmodule ExWebRTC.PeerConnection do
   end
 
   @doc """
-  Send an RTP packet to the peer.
-  Generally called in a loop to move packets between tracks in a media server situation.
+  Send an RTP packet to the remote peer using specified track or its id.
   """
-  @spec send_rtp(peer_connection(), MediaStreamTrack.t() | integer(), ExRTP.Packet.t()) :: :ok
+  @spec send_rtp(
+          peer_connection(),
+          MediaStreamTrack.t() | MediaStreamTrack.id(),
+          ExRTP.Packet.t()
+        ) :: :ok
   def send_rtp(peer_connection, %MediaStreamTrack{id: track_id}, packet),
     do: send_rtp(peer_connection, track_id, packet)
 

--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -167,7 +167,7 @@ defmodule ExWebRTC.PeerConnection do
     GenServer.call(peer_connection, {:remove_track, sender_id})
   end
 
-  @spec send_rtp(peer_connection(), String.t(), ExRTP.Packet.t()) :: :ok
+  @spec send_rtp(peer_connection(), integer(), ExRTP.Packet.t()) :: :ok
   def send_rtp(peer_connection, track_id, packet) do
     GenServer.cast(peer_connection, {:send_rtp, track_id, packet})
   end

--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -715,7 +715,7 @@ defmodule ExWebRTC.PeerConnection do
   end
 
   @impl true
-  def handle_cast({:send_rtp, track_id, packet}, state) do
+  def handle_cast({:send_rtp, %MediaStreamTrack{id: track_id}, packet}, state) do
     # TODO: iterating over transceivers is not optimal
     # but this is, most likely, going to be refactored anyways
     {transceiver, idx} =

--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -167,6 +167,10 @@ defmodule ExWebRTC.PeerConnection do
     GenServer.call(peer_connection, {:remove_track, sender_id})
   end
 
+  @doc """
+  Send an RTP packet to the peer.
+  Generally called in a loop to move packets between tracks in a media server situation.
+  """
   @spec send_rtp(peer_connection(), integer(), ExRTP.Packet.t()) :: :ok
   def send_rtp(peer_connection, track_id, packet) do
     GenServer.cast(peer_connection, {:send_rtp, track_id, packet})

--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -171,8 +171,11 @@ defmodule ExWebRTC.PeerConnection do
   Send an RTP packet to the peer.
   Generally called in a loop to move packets between tracks in a media server situation.
   """
-  @spec send_rtp(peer_connection(), integer(), ExRTP.Packet.t()) :: :ok
-  def send_rtp(peer_connection, track_id, packet) do
+  @spec send_rtp(peer_connection(), MediaStreamTrack.t() | integer(), ExRTP.Packet.t()) :: :ok
+  def send_rtp(peer_connection, %MediaStreamTrack{id: track_id}, packet),
+    do: send_rtp(peer_connection, track_id, packet)
+
+  def send_rtp(peer_connection, track_id, packet) when is_integer(track_id) do
     GenServer.cast(peer_connection, {:send_rtp, track_id, packet})
   end
 


### PR DESCRIPTION
hey, in my experimentation, this handle_cast for `:send_rtp` always receives a full track, not an id. This change makes everything work, but if you want it to be different feel free to edit my pr.