### PR TITLE
Sending RTCP Reports

### DIFF
--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -740,10 +740,10 @@ defmodule ExWebRTC.PeerConnection do
               {packet, state}
           end
 
-        {packet, sender} = RTPSender.send(transceiver.sender, packet)
+        {packet, transceiver} = RTPTransceiver.send_packet(transceiver, packet)
         :ok = DTLSTransport.send_rtp(state.dtls_transport, packet)
 
-        transceivers = List.update_at(state.transceivers, idx, &%{&1 | sender: sender})
+        transceivers = List.replace_at(state.transceivers, idx, transceiver)
         state = %{state | transceivers: transceivers}
 
         {:noreply, state}
@@ -824,8 +824,8 @@ defmodule ExWebRTC.PeerConnection do
           _other -> twcc_recorder
         end
 
-      receiver = RTPReceiver.recv(t.receiver, packet, data)
-      transceivers = List.update_at(state.transceivers, idx, &%{&1 | receiver: receiver})
+      t = RTPTransceiver.receive_packet(t, packet, byte_size(data))
+      transceivers = List.replace_at(state.transceivers, idx, t)
 
       notify(state.owner, {:rtp, t.receiver.track.id, packet})
 

--- a/lib/ex_webrtc/rtp_receiver.ex
+++ b/lib/ex_webrtc/rtp_receiver.ex
@@ -3,29 +3,70 @@ defmodule ExWebRTC.RTPReceiver do
   Implementation of the [RTCRtpReceiver](https://www.w3.org/TR/webrtc/#rtcrtpreceiver-interface).
   """
 
-  alias ExWebRTC.{MediaStreamTrack, Utils}
+  alias ExWebRTC.{MediaStreamTrack, Utils, RTPCodecParameters}
+  alias __MODULE__.ReportRecorder
 
   @type t() :: %__MODULE__{
           track: MediaStreamTrack.t(),
           ssrc: non_neg_integer() | nil,
           bytes_received: non_neg_integer(),
           packets_received: non_neg_integer(),
-          markers_received: non_neg_integer()
+          markers_received: non_neg_integer(),
+          report_recorder: ReportRecorder.t()
         }
 
-  defstruct [:track, :ssrc, bytes_received: 0, packets_received: 0, markers_received: 0]
+  @enforce_keys [:track, :report_recorder]
+  defstruct [
+              ssrc: nil,
+              bytes_received: 0,
+              packets_received: 0,
+              markers_received: 0
+            ] ++ @enforce_keys
 
   @doc false
-  @spec recv(t(), ExRTP.Packet.t(), binary()) :: t()
-  def recv(receiver, packet, raw_packet) do
+  @spec new(MediaStreamTrack.t(), RTPCodecParameters.t() | nil) :: t()
+  def new(track, codec) do
+    report_recorder = %ReportRecorder{
+      clock_rate: codec && codec.clock_rate
+    }
+
+    %__MODULE__{track: track, report_recorder: report_recorder}
+  end
+
+  @doc false
+  @spec update(t(), RTPCodecParameters.t() | nil) :: t()
+  def update(receiver, codec) do
+    # TODO: if clock_rate changed, we should reset the recorder
+    report_recorder = %ReportRecorder{
+      receiver.report_recorder
+      | clock_rate: codec && codec.clock_rate
+    }
+
+    %__MODULE__{receiver | report_recorder: report_recorder}
+  end
+
+  @doc false
+  @spec receive_packet(t(), ExRTP.Packet.t(), non_neg_integer()) :: t()
+  def receive_packet(receiver, packet, size) do
+    report_recorder =
+      ReportRecorder.record_packet(receiver.report_recorder, packet, System.monotonic_time())
+
     # TODO assign ssrc when applying local/remote description.
     %__MODULE__{
       receiver
       | ssrc: packet.ssrc,
-        bytes_received: receiver.bytes_received + byte_size(raw_packet),
+        bytes_received: receiver.bytes_received + size,
         packets_received: receiver.packets_received + 1,
-        markers_received: receiver.markers_received + Utils.to_int(packet.marker)
+        markers_received: receiver.markers_received + Utils.to_int(packet.marker),
+        report_recorder: report_recorder
     }
+  end
+
+  @doc false
+  @spec update_sender_ssrc(t(), non_neg_integer()) :: t()
+  def update_sender_ssrc(receiver, ssrc) do
+    report_recorder = %ReportRecorder{receiver.report_recorder | sender_ssrc: ssrc}
+    %__MODULE__{receiver | report_recorder: report_recorder}
   end
 
   @doc false

--- a/lib/ex_webrtc/rtp_receiver/report_recorder.ex
+++ b/lib/ex_webrtc/rtp_receiver/report_recorder.ex
@@ -80,8 +80,8 @@ defmodule ExWebRTC.RTPReceiver.ReportRecorder do
   Creates an RTCP Receiver Report.
   `time` parameter accepts output of `System.monotonic_time(:native)` as a value.
   """
-  @spec get_report(t(), integer()) :: {ReceiverReport.t(), t()}
-  def get_report(%{media_ssrc: nil}, _time), do: raise("No packet has been recorded yet")
+  @spec get_report(t(), integer()) :: {:ok, ReceiverReport.t(), t()} | {:error, term()}
+  def get_report(%{media_ssrc: nil}, _time), do: {:error, :no_packets}
 
   def(get_report(recorder, time)) do
     received =
@@ -120,7 +120,7 @@ defmodule ExWebRTC.RTPReceiver.ReportRecorder do
         total_lost: total_lost
     }
 
-    {report, recorder}
+    {:ok, report, recorder}
   end
 
   defp record_seq_no(recorder, rtp_seq_no) do

--- a/lib/ex_webrtc/rtp_receiver/report_recorder.ex
+++ b/lib/ex_webrtc/rtp_receiver/report_recorder.ex
@@ -1,5 +1,5 @@
 defmodule ExWebRTC.RTPReceiver.ReportRecorder do
-  @moduledoc false
+  @moduledoc nil
   # based on https://datatracker.ietf.org/doc/html/rfc3550#section-6.4.1
 
   import Bitwise

--- a/lib/ex_webrtc/rtp_sender.ex
+++ b/lib/ex_webrtc/rtp_sender.ex
@@ -6,6 +6,7 @@ defmodule ExWebRTC.RTPSender do
 
   alias ExWebRTC.{MediaStreamTrack, RTPCodecParameters, Utils}
   alias ExSDP.Attribute.Extmap
+  alias __MODULE__.ReportRecorder
 
   @mid_uri "urn:ietf:params:rtp-hdrext:sdes:mid"
 
@@ -22,10 +23,11 @@ defmodule ExWebRTC.RTPSender do
           last_seq_num: non_neg_integer(),
           packets_sent: non_neg_integer(),
           bytes_sent: non_neg_integer(),
-          markers_sent: non_neg_integer()
+          markers_sent: non_neg_integer(),
+          report_recorder: ReportRecorder.t()
         }
 
-  @enforce_keys [:id, :last_seq_num]
+  @enforce_keys [:id, :last_seq_num, :report_recorder]
   defstruct @enforce_keys ++
               [
                 :track,
@@ -61,12 +63,13 @@ defmodule ExWebRTC.RTPSender do
       pt: pt,
       ssrc: ssrc,
       last_seq_num: random_seq_num(),
-      mid: mid
+      mid: mid,
+      report_recorder: %ReportRecorder{clock_rate: codec && codec.clock_rate}
     }
   end
 
   @doc false
-  @spec update(t(), String.t(), RTPCodecParameters.t(), [Extmap.t()]) :: t()
+  @spec update(t(), String.t(), RTPCodecParameters.t() | nil, [Extmap.t()]) :: t()
   def update(sender, mid, codec, rtp_hdr_exts) do
     if sender.mid != nil and mid != sender.mid, do: raise(ArgumentError)
     # convert to a map to be able to find extension id using extension uri
@@ -74,15 +77,27 @@ defmodule ExWebRTC.RTPSender do
     # TODO: handle cases when codec == nil (no valid codecs after negotiation)
     pt = if codec != nil, do: codec.payload_type, else: nil
 
-    %__MODULE__{sender | mid: mid, codec: codec, rtp_hdr_exts: rtp_hdr_exts, pt: pt}
+    report_recorder = %ReportRecorder{
+      sender.report_recorder
+      | clock_rate: codec && codec.clock_rate
+    }
+
+    %__MODULE__{
+      sender
+      | mid: mid,
+        codec: codec,
+        rtp_hdr_exts: rtp_hdr_exts,
+        pt: pt,
+        report_recorder: report_recorder
+    }
   end
 
   # Prepares packet for sending i.e.:
   # * assigns SSRC, pt, seq_num, mid
   # * serializes to binary
   @doc false
-  @spec send(t(), ExRTP.Packet.t()) :: {binary(), t()}
-  def send(sender, packet) do
+  @spec send_packet(t(), ExRTP.Packet.t()) :: {binary(), t()}
+  def send_packet(sender, packet) do
     %Extmap{} = mid_extmap = Map.fetch!(sender.rtp_hdr_exts, @mid_uri)
 
     mid_ext =
@@ -91,6 +106,9 @@ defmodule ExWebRTC.RTPSender do
 
     next_seq_num = sender.last_seq_num + 1 &&& 0xFFFF
     packet = %{packet | payload_type: sender.pt, ssrc: sender.ssrc, sequence_number: next_seq_num}
+
+    report_recorder =
+      ReportRecorder.record_packet(sender.report_recorder, packet, System.os_time())
 
     data =
       packet
@@ -102,7 +120,8 @@ defmodule ExWebRTC.RTPSender do
       | last_seq_num: next_seq_num,
         packets_sent: sender.packets_sent + 1,
         bytes_sent: sender.bytes_sent + byte_size(data),
-        markers_sent: sender.markers_sent + Utils.to_int(packet.marker)
+        markers_sent: sender.markers_sent + Utils.to_int(packet.marker),
+        report_recorder: report_recorder
     }
 
     {data, sender}

--- a/lib/ex_webrtc/rtp_sender/report_recorder.ex
+++ b/lib/ex_webrtc/rtp_sender/report_recorder.ex
@@ -1,5 +1,5 @@
 defmodule ExWebRTC.RTPSender.ReportRecorder do
-  @moduledoc false
+  @moduledoc nil
 
   import Bitwise
 

--- a/test/ex_webrtc/rtp_receiver/report_recorder_test.exs
+++ b/test/ex_webrtc/rtp_receiver/report_recorder_test.exs
@@ -173,7 +173,7 @@ defmodule ExWebRTC.RTPReceiver.ReportRecorderTest do
       |> ReportRecorder.record_report(@sender_report, @rand_ts)
 
     one_second = System.convert_time_unit(1, :second, :native)
-    assert {report, recorder} = ReportRecorder.get_report(recorder, @rand_ts + one_second)
+    assert {:ok, report, recorder} = ReportRecorder.get_report(recorder, @rand_ts + one_second)
     assert %ReceiverReport{reports: [rec_report]} = report
 
     assert %ReceptionReport{
@@ -193,7 +193,9 @@ defmodule ExWebRTC.RTPReceiver.ReportRecorderTest do
         ReportRecorder.record_packet(recorder, packet, @rand_ts)
       end)
 
-    assert {report, _recorder} = ReportRecorder.get_report(recorder, @rand_ts + 2 * one_second)
+    assert {:ok, report, _recorder} =
+             ReportRecorder.get_report(recorder, @rand_ts + 2 * one_second)
+
     assert %ReceiverReport{reports: [rec_report]} = report
 
     lost = 23

--- a/test/ex_webrtc/rtp_receiver_test.exs
+++ b/test/ex_webrtc/rtp_receiver_test.exs
@@ -2,14 +2,16 @@ defmodule ExWebRTC.RTPReceiverTest do
   use ExUnit.Case, async: true
 
   alias ExRTP.Packet
-  alias ExWebRTC.{MediaStreamTrack, RTPReceiver}
+  alias ExWebRTC.{MediaStreamTrack, RTPReceiver, RTPCodecParameters}
+
+  @codec %RTPCodecParameters{payload_type: 111, mime_type: "audio/opus", clock_rate: 48_000}
 
   test "get_stats/2" do
     timestamp = System.os_time(:millisecond)
     payload = <<1, 2, 3>>
 
     track = MediaStreamTrack.new(:audio)
-    receiver = %RTPReceiver{track: track}
+    receiver = RTPReceiver.new(track, @codec)
 
     assert %{
              id: receiver.track.id,
@@ -23,7 +25,7 @@ defmodule ExWebRTC.RTPReceiverTest do
 
     packet1 = Packet.new(payload, ssrc: 1234)
     raw_packet1 = Packet.encode(packet1)
-    receiver = RTPReceiver.recv(receiver, packet1, raw_packet1)
+    receiver = RTPReceiver.receive_packet(receiver, packet1, byte_size(raw_packet1))
 
     assert %{
              id: receiver.track.id,
@@ -37,7 +39,7 @@ defmodule ExWebRTC.RTPReceiverTest do
 
     packet2 = Packet.new(payload, ssrc: 1234, marker: true)
     raw_packet2 = Packet.encode(packet2)
-    receiver = RTPReceiver.recv(receiver, packet2, raw_packet2)
+    receiver = RTPReceiver.receive_packet(receiver, packet2, byte_size(raw_packet2))
 
     assert %{
              id: receiver.track.id,

--- a/test/ex_webrtc/rtp_sender/report_recorder_test.exs
+++ b/test/ex_webrtc/rtp_sender/report_recorder_test.exs
@@ -68,10 +68,10 @@ defmodule ExWebRTC.RTPSender.ReportRecorderTest do
 
   describe "get_report/2" do
     test "properly calculates NTP timestamp" do
-      report =
-        @recorder
-        |> ReportRecorder.record_packet(@packet, 0)
-        |> ReportRecorder.get_report(0)
+      assert {:ok, report, _recorder} =
+               @recorder
+               |> ReportRecorder.record_packet(@packet, 0)
+               |> ReportRecorder.get_report(0)
 
       assert report.ntp_timestamp >>> 32 == @ntp_offset
       assert (report.ntp_timestamp &&& @max_u32) == 0
@@ -81,10 +81,10 @@ defmodule ExWebRTC.RTPSender.ReportRecorderTest do
       # 1/8, so 0.001 in binary 
       frac = 0.125
 
-      report =
-        @recorder
-        |> ReportRecorder.record_packet(@packet, 0)
-        |> ReportRecorder.get_report(trunc((seconds + frac) * native_in_sec))
+      assert {:ok, report, _recorder} =
+               @recorder
+               |> ReportRecorder.record_packet(@packet, 0)
+               |> ReportRecorder.get_report(trunc((seconds + frac) * native_in_sec))
 
       assert report.ntp_timestamp >>> 32 == @ntp_offset + seconds
       assert (report.ntp_timestamp &&& @max_u32) == 1 <<< 29
@@ -93,10 +93,10 @@ defmodule ExWebRTC.RTPSender.ReportRecorderTest do
     test "properly calculates delay since last packet" do
       delta = System.convert_time_unit(250, :millisecond, :native)
 
-      report =
-        @recorder
-        |> ReportRecorder.record_packet(@packet, @rand_ts)
-        |> ReportRecorder.get_report(@rand_ts + delta)
+      assert {:ok, report, _recorder} =
+               @recorder
+               |> ReportRecorder.record_packet(@packet, @rand_ts)
+               |> ReportRecorder.get_report(@rand_ts + delta)
 
       assert report.rtp_timestamp == @rtp_ts + 0.25 * @clock_rate
     end

--- a/test/ex_webrtc/rtp_sender_test.exs
+++ b/test/ex_webrtc/rtp_sender_test.exs
@@ -34,7 +34,7 @@ defmodule ExWebRTC.RTPSenderTest do
 
     packet = ExRTP.Packet.new(<<>>)
 
-    {packet, sender} = RTPSender.send(sender, packet)
+    {packet, sender} = RTPSender.send_packet(sender, packet)
 
     {:ok, packet} = ExRTP.Packet.decode(packet)
 
@@ -51,7 +51,7 @@ defmodule ExWebRTC.RTPSenderTest do
     # check sequence number rollover and marker flag
     sender = %RTPSender{sender | last_seq_num: @max_seq_num}
     packet = ExRTP.Packet.new(<<>>, sequence_number: 1, marker: true)
-    {packet, _sender} = RTPSender.send(sender, packet)
+    {packet, _sender} = RTPSender.send_packet(sender, packet)
     {:ok, packet} = ExRTP.Packet.decode(packet)
     assert packet.sequence_number == 0
     # marker flag shouldn't be overwritten
@@ -73,7 +73,7 @@ defmodule ExWebRTC.RTPSenderTest do
            } == RTPSender.get_stats(sender, timestamp)
 
     packet = ExRTP.Packet.new(payload)
-    {data1, sender} = RTPSender.send(sender, packet)
+    {data1, sender} = RTPSender.send_packet(sender, packet)
 
     assert %{
              timestamp: timestamp,
@@ -86,7 +86,7 @@ defmodule ExWebRTC.RTPSenderTest do
            } == RTPSender.get_stats(sender, timestamp)
 
     packet = ExRTP.Packet.new(payload, marker: true)
-    {data2, sender} = RTPSender.send(sender, packet)
+    {data2, sender} = RTPSender.send_packet(sender, packet)
 
     assert %{
              timestamp: timestamp,


### PR DESCRIPTION
This PR utilises previously added `RTPSender.ReportRecorder` and `RTPReceiver.ReportRecorder` modules to actually track incoming packets and send corresponding RTCP Sender and Receiver Reports.