### PR TITLE
Fix `TWCCRecorder` base timestamp evaluation bug

### DIFF
--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -254,7 +254,7 @@ defmodule ExWebRTC.PeerConnection do
       last_answer: nil,
       peer_fingerprint: nil,
       sent_packets: 0,
-      twcc_recorder: %TWCCRecorder{}
+      twcc_recorder: TWCCRecorder.new()
     }
 
     Process.send_after(self(), :send_twcc_feedback, @twcc_interval)

--- a/lib/ex_webrtc/peer_connection/twcc_recorder.ex
+++ b/lib/ex_webrtc/peer_connection/twcc_recorder.ex
@@ -62,8 +62,10 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorder do
   # start, end - actual range where map values might be set
   # base - from where packets should be added to next feedback
   # if end == start, no packets are available
-  @enforce_keys [:timer, :media_ssrc, :sender_ssrc]
+  @enforce_keys [:timer]
   defstruct [
+              sender_ssrc: nil,
+              media_ssrc: nil,
               base_seq_no: nil,
               start_seq_no: nil,
               end_seq_no: nil,

--- a/lib/ex_webrtc/peer_connection/twcc_recorder.ex
+++ b/lib/ex_webrtc/peer_connection/twcc_recorder.ex
@@ -49,7 +49,7 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorder do
   @default_sender_ssrc 1
 
   @type t() :: %__MODULE__{
-          media_ssrc: non_neg_integer(),
+          media_ssrc: non_neg_integer() | nil,
           sender_ssrc: non_neg_integer() | nil,
           base_seq_no: non_neg_integer() | nil,
           start_seq_no: non_neg_integer() | nil,
@@ -62,14 +62,23 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorder do
   # start, end - actual range where map values might be set
   # base - from where packets should be added to next feedback
   # if end == start, no packets are available
-  defstruct media_ssrc: nil,
-            sender_ssrc: nil,
-            timer: Timer.new(),
-            base_seq_no: nil,
-            start_seq_no: nil,
-            end_seq_no: nil,
-            timestamps: %{},
-            fb_pkt_count: 0
+  @enforce_keys [:timer, :media_ssrc, :sender_ssrc]
+  defstruct [
+              base_seq_no: nil,
+              start_seq_no: nil,
+              end_seq_no: nil,
+              timestamps: %{},
+              fb_pkt_count: 0
+            ] ++ @enforce_keys
+
+  @spec new(non_neg_integer() | nil, non_neg_integer() | nil) :: t()
+  def new(media_ssrc \\ nil, sender_ssrc \\ nil) do
+    %__MODULE__{
+      media_ssrc: media_ssrc,
+      sender_ssrc: sender_ssrc,
+      timer: Timer.new()
+    }
+  end
 
   @spec record_packet(t(), non_neg_integer()) :: t()
   def record_packet(%{start_seq_no: nil, end_seq_no: nil} = recorder, seq_no) do

--- a/test/ex_webrtc/peer_connection/twcc_recorder_test.exs
+++ b/test/ex_webrtc/peer_connection/twcc_recorder_test.exs
@@ -7,7 +7,7 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorderTest do
   @max_seq_no 0xFFFF
   @seq_no 541
 
-  @recorder %TWCCRecorder{sender_ssrc: 1, media_ssrc: 2}
+  @recorder TWCCRecorder.new(1, 2)
 
   describe "record_packet/2" do
     test "initial case" do


### PR DESCRIPTION
The `TWCCRecorder` module has a default argument that keeps the initial value of `System.monotonic_time()` (so the subsequent calls could be offset to be positive, as output of `System.monotonic_time()` is usually negative). The value is evaluated at the compile time and differs from the runtime base `System.monotonic_time()` value, which is obviously undesired. This PR fixes this issue.