### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: Test on OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    name: CI on OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:
         otp: ['26']
@@ -23,7 +23,7 @@ jobs:
         otp-version: ${{matrix.otp}}
         elixir-version: ${{matrix.elixir}}
 
-    - name: Checkout code
+    - name: Checkout the code
       uses: actions/checkout@v4
 
     - name: Cache dependencies
@@ -54,7 +54,7 @@ jobs:
     - name: Install dependencies
       run: mix deps.get
 
-    - name: Compiles without warnings
+    - name: Compile without warnings
       id: compile
       run: mix compile --warnings-as-errors
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,12 @@ jobs:
           ${{ runner.os }}-mix-
 
     - name: Cache dialyzer artifacts
-      id: cache-dialyzer
       uses: actions/cache@v4
       with:
         path: _dialyzer
         key: ${{ runner.os }}-dialyzer-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
-          ${{ runner.os }}-mix-dialyzer-
+          ${{ runner.os }}-dialyzer-
 
     - name: Install dependencies
       run: mix deps.get

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,28 +55,31 @@ jobs:
       run: mix deps.get
 
     - name: Compiles without warnings
+      id: compile
       run: mix compile --warnings-as-errors
 
     - name: Check formatting
-      continue-on-error: true
+      if: steps.compile.outcome == "success"
       run: mix format --check-formatted
 
     - name: Check with credo
-      continue-on-error: true
+      if: steps.compile.outcome == "success"
       run: mix credo
 
     - name: Check with dialyzer
-      continue-on-error: true
+      if: steps.compile.outcome == "success"
       run: mix dialyzer
 
     - name: Check docs
-      continue-on-error: true
+      if: steps.compile.outcome == "success"
       run: mix docs 2>&1 | (! grep -q "warning:")
 
     - name: Run tests and check test coverage
+      if: steps.compile.outcome == "success"
       run: mix coveralls.json
 
     - name: Upload test coverage results to Codecov
+      if: steps.compile.outcome == "success"
       uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: true,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
     - name: Check docs
       run: mix docs 2>&1 | (! grep -q "warning:")
 
-    - name: Run tests and submit test coverage report
-      uses: codecov/codecov-action@v3
+    - name: Run tests and check test coverage
       run: mix coveralls.json
+
+    - name: Upload test coverage results to Codecov
+      uses: codecov/codecov-action@v3
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,15 +58,19 @@ jobs:
       run: mix compile --warnings-as-errors
 
     - name: Check formatting
+      continue-on-error: true
       run: mix format --check-formatted
 
     - name: Check with credo
+      continue-on-error: true
       run: mix credo
 
     - name: Check with dialyzer
+      continue-on-error: true
       run: mix dialyzer
 
     - name: Check docs
+      continue-on-error: true
       run: mix docs 2>&1 | (! grep -q "warning:")
 
     - name: Run tests and check test coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,27 +27,30 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Cache dependencies
-      id: cache-deps
       uses: actions/cache@v3
-      env:
-        cache-name: cache-elixir-deps
       with:
         path: deps
-        key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+        key: ${{ runner.os }}-mix-deps-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
-          ${{ runner.os }}-mix-${{ env.cache-name }}-
+          ${{ runner.os }}-mix-deps-
 
     - name: Cache compiled build
-      id: cache-build
       uses: actions/cache@v3
-      env:
-        cache-name: cache-compiled-build
       with:
         path: _build
-        key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+        key: ${{ runner.os }}-mix-build-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
-          ${{ runner.os }}-mix-${{ env.cache-name }}-
+          ${{ runner.os }}-mix-build-
           ${{ runner.os }}-mix-
+
+    - name: Cache dialyzer artifacts
+      id: cache-dialyzer
+      uses: actions/cache@v3
+      with:
+        path: _dialyzer
+        key: ${{ runner.os }}-dialyzer-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-mix-dialyzer-
 
     - name: Install dependencies
       run: mix deps.get

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,42 +1,72 @@
-name: CI 
+name: CI
 
 on: push
 
-jobs:
-  lint:
-    runs-on: ubuntu-latest
-    name: Lint (OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}})
-    strategy:
-      matrix:
-        otp: ['26']
-        elixir: ['1.15']
-    steps:
-      - uses: actions/checkout@v3
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
-      - run: mix deps.get
-      - run: mix credo
-      - run: mix dialyzer
-      - run: mix format --check-formatted
-      - run: mix docs 2>&1 | (! grep -q "warning:")
+env:
+  MIX_ENV: test
 
+permissions:
+  contents: read
+
+jobs:
   test:
     runs-on: ubuntu-latest
-    name: Test (OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}})
+    name: Test on OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:
         otp: ['26']
-        elixir: ['1.15']
-    env:
-      MIX_ENV: test
+        elixir: ['1.16']
     steps:
-      - uses: actions/checkout@v3
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
-      - run: mix deps.get
-      - run: mix coveralls.json
-      - uses: codecov/codecov-action@v3
+    - name: Set up Elixir
+      uses: erlef/setup-beam@v1
+      with:
+        otp-version: ${{matrix.otp}}
+        elixir-version: ${{matrix.elixir}}
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Cache dependencies
+      id: cache-deps
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-elixir-deps
+      with:
+        path: deps
+        key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-mix-${{ env.cache-name }}-
+
+    - name: Cache compiled build
+      id: cache-build
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-compiled-build
+      with:
+        path: _build
+        key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-mix-${{ env.cache-name }}-
+          ${{ runner.os }}-mix-
+
+    - name: Install dependencies
+      run: mix deps.get
+
+    - name: Compiles without warnings
+      run: mix compile --warnings-as-errors
+
+    - name: Check formatting
+      run: mix format --check-formatted
+
+    - name: Check with credo
+      run: mix credo
+
+    - name: Check with dialyzer
+      run: mix dialyzer
+
+    - name: Check docs
+      run: mix docs 2>&1 | (! grep -q "warning:")
+
+    - name: Run tests and submit test coverage report
+      uses: codecov/codecov-action@v3
+      run: mix coveralls.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,27 +59,28 @@ jobs:
       run: mix compile --warnings-as-errors
 
     - name: Check formatting
-      if: steps.compile.outcome == "success"
+      if: ${{ steps.compile.outcome == 'success' }}
       run: mix format --check-formatted
 
     - name: Check with credo
-      if: steps.compile.outcome == "success"
+      if: ${{ steps.compile.outcome == 'success' }}
       run: mix credo
 
     - name: Check with dialyzer
-      if: steps.compile.outcome == "success"
+      if: ${{ steps.compile.outcome == 'success' }}
       run: mix dialyzer
 
     - name: Check docs
-      if: steps.compile.outcome == "success"
+      if: ${{ steps.compile.outcome == 'success' }}
       run: mix docs 2>&1 | (! grep -q "warning:")
 
     - name: Run tests and check test coverage
-      if: steps.compile.outcome == "success"
+      if: ${{ steps.compile.outcome == 'success' }}
+      id: test
       run: mix coveralls.json
 
     - name: Upload test coverage results to Codecov
-      if: steps.compile.outcome == "success"
+      if: ${{ steps.test.outcome == 'success' }}
       uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: true,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
         elixir-version: ${{matrix.elixir}}
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: deps
         key: ${{ runner.os }}-mix-deps-${{ hashFiles('**/mix.lock') }}
@@ -35,7 +35,7 @@ jobs:
           ${{ runner.os }}-mix-deps-
 
     - name: Cache compiled build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: _build
         key: ${{ runner.os }}-mix-build-${{ hashFiles('**/mix.lock') }}
@@ -45,7 +45,7 @@ jobs:
 
     - name: Cache dialyzer artifacts
       id: cache-dialyzer
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: _dialyzer
         key: ${{ runner.os }}-dialyzer-${{ hashFiles('**/mix.lock') }}
@@ -74,5 +74,5 @@ jobs:
       run: mix coveralls.json
 
     - name: Upload test coverage results to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,28 +59,28 @@ jobs:
       run: mix compile --warnings-as-errors
 
     - name: Check formatting
-      if: ${{ !canceled() && steps.compile.outcome == 'success' }}
+      if: ${{ !cancelled() && steps.compile.outcome == 'success' }}
       run: mix format --check-formatted
 
     - name: Check with credo
-      if: ${{ !canceled() && steps.compile.outcome == 'success' }}
+      if: ${{ !cancelled() && steps.compile.outcome == 'success' }}
       run: mix credo
 
     - name: Check with dialyzer
-      if: ${{ !canceled() && steps.compile.outcome == 'success' }}
+      if: ${{ !cancelled() && steps.compile.outcome == 'success' }}
       run: mix dialyzer
 
     - name: Check docs
-      if: ${{ !canceled() && steps.compile.outcome == 'success' }}
+      if: ${{ !cancelled() && steps.compile.outcome == 'success' }}
       run: mix docs 2>&1 | (! grep -q "warning:")
 
     - name: Run tests and check test coverage
-      if: ${{ !canceled() && steps.compile.outcome == 'success' }}
+      if: ${{ !cancelled() && steps.compile.outcome == 'success' }}
       id: test
       run: mix coveralls.json
 
     - name: Upload test coverage results to Codecov
-      if: ${{ !canceled() && steps.test.outcome == 'success' }}
+      if: ${{ !cancelled() && steps.test.outcome == 'success' }}
       uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: true,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,28 +59,28 @@ jobs:
       run: mix compile --warnings-as-errors
 
     - name: Check formatting
-      if: ${{ steps.compile.outcome == 'success' }}
+      if: ${{ !canceled() && steps.compile.outcome == 'success' }}
       run: mix format --check-formatted
 
     - name: Check with credo
-      if: ${{ steps.compile.outcome == 'success' }}
+      if: ${{ !canceled() && steps.compile.outcome == 'success' }}
       run: mix credo
 
     - name: Check with dialyzer
-      if: ${{ steps.compile.outcome == 'success' }}
+      if: ${{ !canceled() && steps.compile.outcome == 'success' }}
       run: mix dialyzer
 
     - name: Check docs
-      if: ${{ steps.compile.outcome == 'success' }}
+      if: ${{ !canceled() && steps.compile.outcome == 'success' }}
       run: mix docs 2>&1 | (! grep -q "warning:")
 
     - name: Run tests and check test coverage
-      if: ${{ steps.compile.outcome == 'success' }}
+      if: ${{ !canceled() && steps.compile.outcome == 'success' }}
       id: test
       run: mix coveralls.json
 
     - name: Upload test coverage results to Codecov
-      if: ${{ steps.test.outcome == 'success' }}
+      if: ${{ !canceled() && steps.test.outcome == 'success' }}
       uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: true,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,6 @@ jobs:
 
     - name: Upload test coverage results to Codecov
       uses: codecov/codecov-action@v4
-
+      with:
+        fail_ci_if_error: true,
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,8 @@ ex_webrtc-*.tar
 # Temporary files, for example, from tests.
 /tmp/
 
+# Localy stored dialyzer artifacts
+/_dialyzer/
+
 # I hate MacOS
 .DS_Store

--- a/lib/ex_webrtc/media/ivf/writer.ex
+++ b/lib/ex_webrtc/media/ivf/writer.ex
@@ -94,13 +94,9 @@ defmodule ExWebRTC.Media.IVF.Writer do
     len_frame = byte_size(frame.data)
     serialized_frame = <<len_frame::little-32, frame.timestamp::little-64, frame.data::binary>>
 
-    case IO.binwrite(writer.file, serialized_frame) do
-      :ok ->
-        writer = %{writer | frames_cnt: writer.frames_cnt + 1}
-        {:ok, writer}
+    :ok = IO.binwrite(writer.file, serialized_frame)
 
-      {:error, _reason} = error ->
-        error
-    end
+    writer = %{writer | frames_cnt: writer.frames_cnt + 1}
+    {:ok, writer}
   end
 end

--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -1009,8 +1009,7 @@ defmodule ExWebRTC.PeerConnection do
     final_mlines =
       current_local_desc.media
       |> Stream.with_index()
-                     |> Enum.map(fn {local_mline, idx} ->
-
+      |> Enum.map(fn {local_mline, idx} ->
         case Enum.find(transceivers, &(&1.mline_idx == idx)) do
           # if there is no transceiver, the mline must have been rejected
           # in the past (in the offer or answer) so we always set the port to 0

--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -1009,7 +1009,8 @@ defmodule ExWebRTC.PeerConnection do
     final_mlines =
       current_local_desc.media
       |> Stream.with_index()
-      |> Enum.map(fn {local_mline, idx} ->
+                     |> Enum.map(fn {local_mline, idx} ->
+
         case Enum.find(transceivers, &(&1.mline_idx == idx)) do
           # if there is no transceiver, the mline must have been rejected
           # in the past (in the offer or answer) so we always set the port to 0

--- a/mix.exs
+++ b/mix.exs
@@ -19,6 +19,12 @@ defmodule ExWebRTC.MixProject do
       docs: docs(),
       source_url: @source_url,
 
+      # dialyzer
+      dialyzer: [
+        plt_local_path: "_dialyzer",
+        plt_core_path: "_dialyzer"
+      ],
+
       # code coverage
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start(capture_log: true, assert_receive_timeout: 400)
+ExUnit.start(capture_log: true, assert_receive_timeout: 500)


### PR DESCRIPTION
This PR:
- adds caching of `deps`, `_build` and `dialyzer` artifacts,
- updates some of the actions versions (and thus removes warnings),
- consolidates everything into a single GH Workflow job (both of previous jobs required compilation and now it's very fast anyways).

Thanks to this the CI should be much, much faster.

Based on https://fly.io/docs/elixir/advanced-guides/github-actions-elixir-ci-cd/ and https://www.alanvardy.com/post/caching-dialyzer with some tweaks here and there.