### PR TITLE
Allow `add_ice_candidate` when `current_remote_description` is not set

### DIFF
--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -433,9 +433,13 @@ defmodule ExWebRTC.PeerConnection do
   end
 
   @impl true
-  def handle_call({:add_ice_candidate, _}, _from, %{current_remote_desc: nil} = state) do
-    {:reply, {:error, :no_remote_description}, state}
-  end
+  def handle_call(
+        {:add_ice_candidate, _},
+        _from,
+        %{current_remote_desc: crd, pending_remote_desc: prd} = state
+      )
+      when is_nil(prd) and is_nil(crd),
+      do: {:reply, {:error, :no_remote_description}, state}
 
   @impl true
   def handle_call({:add_ice_candidate, %{candidate: ""}}, _from, state) do


### PR DESCRIPTION
This PR fixes a bug that makes it impossible to use `add_ice_candidate` with only pending remote description.