### PR TITLE
Handle incoming data before receiving an answer

### DIFF
--- a/lib/ex_webrtc/dtls_transport.ex
+++ b/lib/ex_webrtc/dtls_transport.ex
@@ -106,7 +106,8 @@ defmodule ExWebRTC.DTLSTransport do
       ice_transport: ice_transport,
       ice_pid: ice_pid,
       ice_connected: false,
-      buffered_packets: nil,
+      buffered_local_packets: nil,
+      buffered_remote_packets: nil,
       cert: cert,
       base64_cert: Base.encode64(cert),
       pkey: pkey,
@@ -148,10 +149,10 @@ defmodule ExWebRTC.DTLSTransport do
   def handle_call(:set_ice_connected, _from, state) do
     state = %{state | ice_connected: true}
 
-    if state.buffered_packets do
+    if state.buffered_local_packets do
       Logger.debug("Sending buffered DTLS packets")
-      :ok = state.ice_transport.send_data(state.ice_pid, state.buffered_packets)
-      state = %{state | buffered_packets: nil}
+      :ok = state.ice_transport.send_data(state.ice_pid, state.buffered_local_packets)
+      state = %{state | buffered_local_packets: nil}
       {:reply, :ok, state}
     else
       {:reply, :ok, state}
@@ -205,7 +206,21 @@ defmodule ExWebRTC.DTLSTransport do
         verify_peer: true
       )
 
-    state = %{state | dtls: dtls, mode: mode, peer_fingerprint: peer_fingerprint}
+    # plant the buffered remote packets in the mailbox
+    # as if it came from the ICE transport
+    case state.buffered_remote_packets do
+      nil -> :ok
+      data -> send(self(), {:ex_ice, state.ice_pid, {:data, data}})
+    end
+
+    state = %{
+      state
+      | dtls: dtls,
+        mode: mode,
+        peer_fingerprint: peer_fingerprint,
+        buffered_remote_packets: nil
+    }
+
     {:reply, :ok, state}
   end
 
@@ -242,14 +257,14 @@ defmodule ExWebRTC.DTLSTransport do
   end
 
   @impl true
-  def handle_info(:dtls_timeout, %{buffered_packets: buffered_packets} = state) do
+  def handle_info(:dtls_timeout, %{buffered_local_packets: buffered_local_packets} = state) do
     case ExDTLS.handle_timeout(state.dtls) do
       {:retransmit, packets, timeout} when state.ice_connected ->
         state.ice_transport.send_data(state.ice_pid, packets)
         Logger.debug("Retransmitted DTLS packets")
         Process.send_after(self(), :dtls_timeout, timeout)
 
-      {:retransmit, ^buffered_packets, timeout} ->
+      {:retransmit, ^buffered_local_packets, timeout} ->
         # we got DTLS packets from the other side but
         # we haven't established ICE connection yet so
         # packets to retransmit have to be the same as dtls_buffered_packets
@@ -282,6 +297,13 @@ defmodule ExWebRTC.DTLSTransport do
     Logger.debug("Stopping DTLSTransport with reason: #{inspect(reason)}")
   end
 
+  defp handle_ice_data({:data, data}, %{dtls: nil} = state) do
+    # received DTLS data from remote peer before receiving an
+    # SDP answer and initializing the DTLS Transport, will buffer the data
+    state = %{state | buffered_remote_packets: data}
+    {:ok, state}
+  end
+
   defp handle_ice_data({:data, <<f, _rest::binary>> = data}, state) when f in 20..64 do
     case ExDTLS.handle_data(state.dtls, data) do
       {:handshake_packets, packets, timeout} when state.ice_connected ->
@@ -297,7 +319,7 @@ defmodule ExWebRTC.DTLSTransport do
         """)
 
         Process.send_after(self(), :dtls_timeout, timeout)
-        state = %{state | buffered_packets: packets}
+        state = %{state | buffered_local_packets: packets}
         state = update_dtls_state(state, :connecting)
         {:ok, state}
 

--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -1165,16 +1165,16 @@ defmodule ExWebRTC.PeerConnection do
       transceivers =
         process_mlines_remote(sdp.media, state.transceivers, type, state.config, state.owner)
 
+      # infer our role from the remote role
+      dtls_role = if dtls_role in [:actpass, :passive], do: :active, else: :passive
+      DTLSTransport.start_dtls(state.dtls_transport, dtls_role, peer_fingerprint)
+
       # TODO: this can result in ICE restart (when it should, e.g. when this is answer)
       :ok = state.ice_transport.set_remote_credentials(state.ice_pid, ice_ufrag, ice_pwd)
 
       for candidate <- SDPUtils.get_ice_candidates(sdp) do
         state.ice_transport.add_remote_candidate(state.ice_pid, candidate)
       end
-
-      # infer our role from the remote role
-      dtls_role = if dtls_role in [:actpass, :passive], do: :active, else: :passive
-      DTLSTransport.start_dtls(state.dtls_transport, dtls_role, peer_fingerprint)
 
       state =
         state


### PR DESCRIPTION
This PR makes it possible to receive data (e.g. DTLS handshake packets) from the remote peer before receiving an answer.

Now:
1. Our ICE implementation allows data from unauthorised peer (so before we receive their credentials in an answer),
2. DTLS requires remote's certs to perform the handshake.

`DTLSTransport` will now buffer packets received before receiving an answer and handle them after the transport has been initialised (so after answer has been set).