### PR TITLE
Improve the structs in the API, add docs

### DIFF
--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -25,55 +25,65 @@ defmodule ExWebRTC.PeerConnection do
   }
 
   @twcc_interval 100
+  @twcc_uri "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01"
 
   @type peer_connection() :: GenServer.server()
 
-  @type offer_options() :: [ice_restart: boolean()]
-  @type answer_options() :: []
-
-  @type transceiver_options() :: [direction: RTPTransceiver.direction()]
-
   @typedoc """
-  Messages sent by the ExWebRTC.
+  Possible connection states.
+
+  For the exact meaning, refer to the [RTCPeerConnection: connectionState property](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/connectionState).
   """
-  @type signal() ::
-          {:ex_webrtc, pid(),
-           :negotiation_needed
-           | {:ice_candidate, ICECandidate.t()}
-           | {:ice_gathering_state_change, gathering_state()}
-           | {:signaling_state_change, signaling_state()}
-           | {:connection_state_change, connection_state()}
-           | {:track, MediaStreamTrack.t()}
-           | {:track_muted, MediaStreamTrack.id()}
-           | {:track_ended, MediaStreamTrack.id()}
-           | {:rtp, MediaStreamTrack.id(), ExRTP.Packet.t()}}
+  @type connection_state() :: :new | :connecting | :connected | :disconnected | :failed | :closed
 
   @typedoc """
   Possible ICE gathering states.
 
-  For the exact meaning, refer to the [WebRTC W3C, section 4.3.2](https://www.w3.org/TR/webrtc/#rtcicegatheringstate-enum)
+  For the exact meaning, refer to the [RTCPeerConnection: iceGatheringState property](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceGatheringState).
   """
-  @type gathering_state() :: :new | :gathering | :complete
+  @type ice_gathering_state() :: :new | :gathering | :complete
 
   @typedoc """
-  Possible PeerConnection signaling states.
+  Possible ICE connection states.
 
-  For the exact meaning, refer to the [WebRTC W3C, section 4.3.1](https://www.w3.org/TR/webrtc/#dom-rtcsignalingstate)
+  For the exact meaning, refer to the [RTCPeerConnection: iceConnectionState property](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceConnectionState).
+  """
+  @type ice_connection_state() ::
+          :new | :checking | :connected | :completed | :failed | :disconnected | :closed
+
+  @typedoc """
+  Possible signaling states.
+
+  For the exact meaning, refer to the [RTCPeerConnection: signalingState property](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/signalingState).
   """
   @type signaling_state() :: :stable | :have_local_offer | :have_remote_offer
 
   @typedoc """
-  Possible PeerConnection states.
+  Messages sent by the the `ExWebRTC.PeerConnection` process to its controlling process.
 
-  For the exact meaning, refer to the [WebRTC W3C, section 4.3.3](https://www.w3.org/TR/webrtc/#rtcpeerconnectionstate-enum)
+  Most of the messages match the [RTCPeerConnection events](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection#events),
+  except for:
+  * `:track_muted`, `:track_ended` - these match the [MediaStreamTrack events](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack#events).
+  * `:rtp` and `:rtcp` - these contain packets received by the PeerConnection.
   """
-  @type connection_state() :: :closed | :failed | :disconnected | :new | :connecting | :connected
+  @type message() ::
+          {:ex_webrtc, pid(),
+           {:connection_state_change, connection_state()}
+           | {:ice_candidate, ICECandidate.t()}
+           | {:ice_connection_state_change, ice_connection_state()}
+           | {:ice_gathering_state_change, ice_gathering_state()}
+           | :negotiation_needed
+           | {:signaling_state_change, signaling_state()}
+           | {:track, MediaStreamTrack.t()}
+           | {:track_muted, MediaStreamTrack.id()}
+           | {:track_ended, MediaStreamTrack.id()}
+           | {:rtp, MediaStreamTrack.id(), ExRTP.Packet.t()}}
+          | {:rtcp, [ExRTCP.Packet.packet()]}
 
-  @twcc_uri "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01"
+  #### NON-MDN-API ####
 
-  #### API ####
   @doc """
-  Returns a list of all running peer connections.
+  Returns a list of all running `ExWebRTC.PeerConnection` processes.
   """
   @spec get_all_running() :: [pid()]
   def get_all_running() do
@@ -81,6 +91,25 @@ defmodule ExWebRTC.PeerConnection do
     |> Enum.filter(fn pid -> Process.alive?(pid) end)
   end
 
+  @doc """
+  Starts a new `ExWebRTC.PeerConnection` process.
+
+  `ExWebRTC.PeerConnection` is a `GenServer` under the hood, thus this function allows for
+  passing the generic `t:GenServer.options/0` as an argument.
+  """
+  @spec start(Configuration.options(), GenServer.options()) :: GenServer.on_start()
+  def start(pc_opts \\ [], gen_server_opts \\ []) do
+    {controlling_process, pc_opts} = Keyword.pop(pc_opts, :controlling_process)
+    controlling_process = controlling_process || self()
+    configuration = Configuration.from_options!(pc_opts)
+    GenServer.start(__MODULE__, {controlling_process, configuration}, gen_server_opts)
+  end
+
+  @doc """
+  Starts a new `ExWebRTC.PeerConnection` process.
+
+  Works identically to `start/2`, but links to the calling process.
+  """
   @spec start_link(Configuration.options(), GenServer.options()) :: GenServer.on_start()
   def start_link(pc_opts \\ [], gen_server_opts \\ []) do
     {controlling_process, pc_opts} = Keyword.pop(pc_opts, :controlling_process)
@@ -89,115 +118,19 @@ defmodule ExWebRTC.PeerConnection do
     GenServer.start_link(__MODULE__, {controlling_process, configuration}, gen_server_opts)
   end
 
-  @spec start(Configuration.options()) :: GenServer.on_start()
-  def start(options \\ []) do
-    configuration = Configuration.from_options!(options)
-    GenServer.start(__MODULE__, {self(), configuration})
-  end
+  @doc """
+  Changes the controlling process of this `peer_connection` process.
 
+  Controlling process is a process that receives all of the messages (descirbed
+  by `t:message/0`) from this PeerConnection.
+  """
   @spec controlling_process(peer_connection(), Process.dest()) :: :ok
   def controlling_process(peer_connection, controlling_process) do
     GenServer.call(peer_connection, {:controlling_process, controlling_process})
   end
 
-  @spec create_offer(peer_connection(), offer_options()) ::
-          {:ok, SessionDescription.t()} | {:error, :invalid_state}
-  def create_offer(peer_connection, options \\ []) do
-    GenServer.call(peer_connection, {:create_offer, options})
-  end
-
-  @spec create_answer(peer_connection(), answer_options()) ::
-          {:ok, SessionDescription.t()} | {:error, :invalid_state}
-  def create_answer(peer_connection, options \\ []) do
-    GenServer.call(peer_connection, {:create_answer, options})
-  end
-
-  @spec set_local_description(peer_connection(), SessionDescription.t()) ::
-          :ok | {:error, atom()}
-  def set_local_description(peer_connection, description) do
-    GenServer.call(peer_connection, {:set_local_description, description})
-  end
-
-  @spec get_local_description(peer_connection()) :: SessionDescription.t() | nil
-  def get_local_description(peer_connection) do
-    GenServer.call(peer_connection, :get_local_description)
-  end
-
-  @spec get_current_local_description(peer_connection()) :: SessionDescription.t() | nil
-  def get_current_local_description(peer_connection) do
-    GenServer.call(peer_connection, :get_current_local_description)
-  end
-
-  @spec set_remote_description(peer_connection(), SessionDescription.t()) ::
-          :ok | {:error, atom()}
-  def set_remote_description(peer_connection, description) do
-    GenServer.call(peer_connection, {:set_remote_description, description})
-  end
-
-  @spec get_remote_description(peer_connection()) :: SessionDescription.t() | nil
-  def get_remote_description(peer_connection) do
-    GenServer.call(peer_connection, :get_remote_description)
-  end
-
-  @spec get_current_remote_description(peer_connection()) :: SessionDescription.t() | nil
-  def get_current_remote_description(peer_connection) do
-    GenServer.call(peer_connection, :get_current_remote_description)
-  end
-
-  @spec add_ice_candidate(peer_connection(), ICECandidate.t()) ::
-          :ok | {:error, :no_remote_description}
-  def add_ice_candidate(peer_connection, candidate) do
-    GenServer.call(peer_connection, {:add_ice_candidate, candidate})
-  end
-
-  @spec get_transceivers(peer_connection()) :: [RTPTransceiver.t()]
-  def get_transceivers(peer_connection) do
-    GenServer.call(peer_connection, :get_transceivers)
-  end
-
-  @spec add_transceiver(
-          peer_connection(),
-          RTPTransceiver.kind() | MediaStreamTrack.t(),
-          transceiver_options()
-        ) :: {:ok, RTPTransceiver.t()}
-  def add_transceiver(peer_connection, kind_or_track, options \\ []) do
-    GenServer.call(peer_connection, {:add_transceiver, kind_or_track, options})
-  end
-
-  @spec set_transceiver_direction(
-          peer_connection(),
-          RTPTransceiver.id(),
-          RTPTransceiver.direction()
-        ) :: :ok | {:error, :invalid_transceiver_id}
-  def set_transceiver_direction(peer_connection, transceiver_id, direction)
-      when direction in [:sendrecv, :sendonly, :recvonly, :inactive] do
-    GenServer.call(peer_connection, {:set_transceiver_direction, transceiver_id, direction})
-  end
-
-  @spec stop_transceiver(peer_connection(), RTPTransceiver.id()) ::
-          :ok | {:error, :invalid_transceiver_id}
-  def stop_transceiver(peer_connection, transceiver_id) do
-    GenServer.call(peer_connection, {:stop_transceiver, transceiver_id})
-  end
-
-  @spec add_track(peer_connection(), MediaStreamTrack.t()) :: {:ok, RTPSender.t()}
-  def add_track(peer_connection, track) do
-    GenServer.call(peer_connection, {:add_track, track})
-  end
-
-  @spec replace_track(peer_connection(), RTPSender.id(), MediaStreamTrack.t()) ::
-          :ok | {:error, :invalid_sender_id | :invalid_track_type}
-  def replace_track(peer_connection, sender_id, track) do
-    GenServer.call(peer_connection, {:replace_track, sender_id, track})
-  end
-
-  @spec remove_track(peer_connection(), RTPSender.id()) :: :ok | {:error, :invalid_sender_id}
-  def remove_track(peer_connection, sender_id) do
-    GenServer.call(peer_connection, {:remove_track, sender_id})
-  end
-
   @doc """
-  Send an RTP packet to the remote peer using specified track or its id.
+  Sends an RTP packet to the remote peer using the track specified by the `track_id`.
 
   Options:
     * `rtx?` - send the packet as if it was retransmited (use SSRC and payload type specific to RTX)
@@ -213,16 +146,129 @@ defmodule ExWebRTC.PeerConnection do
   end
 
   @doc """
-  Send an RTCP PLI feedback to the remote peer using specified track.
+  Sends an RTCP PLI feedback to the remote peer using the track specified by the `track_id`.
   """
   @spec send_pli(peer_connection(), MediaStreamTrack.id()) :: :ok
   def send_pli(peer_connection, track_id) do
     GenServer.cast(peer_connection, {:send_pli, track_id})
   end
 
-  @doc """
-  Returns peer connection's statistics.
+  #### MDN-API ####
 
+  @doc """
+  Returns the connection state.
+
+  For more information, refer to the [RTCPeerConnection: connectionState property](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/connectionState).
+  """
+  @spec get_connection_state(peer_connection()) :: connection_state()
+  def get_connection_state(peer_connection) do
+    GenServer.call(peer_connection, :get_connection_state)
+  end
+
+  @doc """
+  Returns the ICE connection state.
+
+  For more information, refer to the [RTCPeerConnection: iceConnectionState property](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceConnectionState).
+  """
+  @spec get_ice_connection_state(peer_connection()) :: ice_connection_state()
+  def get_ice_connection_state(peer_connection) do
+    GenServer.call(peer_connection, :get_ice_connection_state)
+  end
+
+  @doc """
+  Returns the ICE gathering state.
+
+  For more information, refer to the [RTCPeerConnection: iceGatheringState property](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceGatheringState).
+  """
+  @spec get_ice_gathering_state(peer_connection()) :: ice_gathering_state()
+  def get_ice_gathering_state(peer_connection) do
+    GenServer.call(peer_connection, :get_ice_gathering_state)
+  end
+
+  @doc """
+  Returns the signaling state.
+
+  For more information, refer to the [RTCPeerConnection: signalingState property](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/signalingState).
+  """
+  @spec get_signaling_state(peer_connection()) :: signaling_state()
+  def get_signaling_state(peer_connection) do
+    GenServer.call(peer_connection, :get_signaling_state)
+  end
+
+  @doc """
+  Returns the local description.
+
+  For more information, refer to the [RTCPeerConnection: localDescription property](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/localDescription).
+  """
+  @spec get_local_description(peer_connection()) :: SessionDescription.t() | nil
+  def get_local_description(peer_connection) do
+    GenServer.call(peer_connection, :get_local_description)
+  end
+
+  @doc """
+  Returns the remote description.
+
+  For more information, refer to the [RTCPeerConnection: remoteDescription property](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/remoteDescription).
+  """
+  @spec get_remote_description(peer_connection()) :: SessionDescription.t() | nil
+  def get_remote_description(peer_connection) do
+    GenServer.call(peer_connection, :get_remote_description)
+  end
+
+  @doc """
+  Returns the pending local description.
+
+  For more information, refer to the [RTCPeerConnection: pendingLocalDescription property](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/pendingLocalDescription).
+  """
+  @spec get_pending_local_description(peer_connection()) :: SessionDescription.t() | nil
+  def get_pending_local_description(peer_connection) do
+    GenServer.call(peer_connection, :get_pending_local_description)
+  end
+
+  @doc """
+  Returns the pending remote description.
+
+  For more information, refer to the [RTCPeerConnection: pendingRemoteDescription property](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/pendingRemoteDescription).
+  """
+  @spec get_pending_remote_description(peer_connection()) :: SessionDescription.t() | nil
+  def get_pending_remote_description(peer_connection) do
+    GenServer.call(peer_connection, :get_pending_remote_description)
+  end
+
+  @doc """
+  Returns the current local description.
+
+  For more information, refer to the [RTCPeerConnection: currentLocalDescription property](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/currentLocalDescription).
+  """
+  @spec get_current_local_description(peer_connection()) :: SessionDescription.t() | nil
+  def get_current_local_description(peer_connection) do
+    GenServer.call(peer_connection, :get_current_local_description)
+  end
+
+  @doc """
+  Returns the current remote description.
+
+  For more information, refer to the [RTCPeerConnection: currentRemoteDescription property](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/currentRemoteDescription).
+  """
+  @spec get_current_remote_description(peer_connection()) :: SessionDescription.t() | nil
+  def get_current_remote_description(peer_connection) do
+    GenServer.call(peer_connection, :get_current_remote_description)
+  end
+
+  @doc """
+  Returns the list of transceivers.
+
+  For more information, refer to the [RTCPeerConnection: getTransceivers() method](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/getTransceivers).
+  """
+  @spec get_transceivers(peer_connection()) :: [RTPTransceiver.t()]
+  def get_transceivers(peer_connection) do
+    GenServer.call(peer_connection, :get_transceivers)
+  end
+
+  @doc """
+  Returns PeerConnection's statistics.
+
+  For more information, refer to the [RTCPeerConnection: getStats() method](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/getStats).
   See [RTCStatsReport](https://www.w3.org/TR/webrtc/#rtcstatsreport-object) for the output structure.
   """
   @spec get_stats(peer_connection()) :: %{(atom() | integer()) => map()}
@@ -230,6 +276,134 @@ defmodule ExWebRTC.PeerConnection do
     GenServer.call(peer_connection, :get_stats)
   end
 
+  @doc """
+  Sets the local description.
+
+  For more information, refer to the [RTCPeerConnection: setLocalDescription() method](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/setLocalDescription).
+  """
+  @spec set_local_description(peer_connection(), SessionDescription.t()) :: :ok | {:error, term()}
+  def set_local_description(peer_connection, description) do
+    GenServer.call(peer_connection, {:set_local_description, description})
+  end
+
+  @doc """
+  Sets the remote description.
+
+  For more information, refer to the [RTCPeerConnection: setRemoteDescription() method](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/setRemoteDescription).
+  """
+  @spec set_remote_description(peer_connection(), SessionDescription.t()) ::
+          :ok | {:error, term()}
+  def set_remote_description(peer_connection, description) do
+    GenServer.call(peer_connection, {:set_remote_description, description})
+  end
+
+  @doc """
+  Creates an SDP offer.
+
+  For more information, refer to the [RTCPeerConnection: createOffer() method](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createOffer).
+  """
+  @spec create_offer(peer_connection(), restart_ice?: boolean()) ::
+          {:ok, SessionDescription.t()} | {:error, term()}
+  def create_offer(peer_connection, options \\ []) do
+    GenServer.call(peer_connection, {:create_offer, options})
+  end
+
+  @doc """
+  Creates an SDP answer.
+
+  For more information, refer to the [RTCPeerConnection: createAnswer() method](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createAnswer).
+  """
+  @spec create_answer(peer_connection()) :: {:ok, SessionDescription.t()} | {:error, term()}
+  def create_answer(peer_connection) do
+    GenServer.call(peer_connection, :create_answer)
+  end
+
+  @doc """
+  Adds a new remote ICE candidate.
+
+  For more information, refer to the [RTCPeerConnection: addIceCandidate() method](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addIceCandidate).
+  """
+  @spec add_ice_candidate(peer_connection(), ICECandidate.t()) :: :ok | {:error, term()}
+  def add_ice_candidate(peer_connection, candidate) do
+    GenServer.call(peer_connection, {:add_ice_candidate, candidate})
+  end
+
+  @doc """
+  Adds a new transceiver to this PeerConnection.
+
+  For more information, refer to the [RTCPeerConnection: addTransceiver() method](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addTransceiver).
+  """
+  @spec add_transceiver(
+          peer_connection(),
+          RTPTransceiver.kind() | MediaStreamTrack.t(),
+          direction: RTPTransceiver.direction()
+        ) :: {:ok, RTPTransceiver.t()}
+  def add_transceiver(peer_connection, kind_or_track, options \\ []) do
+    GenServer.call(peer_connection, {:add_transceiver, kind_or_track, options})
+  end
+
+  @doc """
+  Sets the direction of transceiver specified by the `id`.
+
+  For more information, refer to the [RTCRtpTransceiver: direction property](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver/direction).
+  """
+  @spec set_transceiver_direction(
+          peer_connection(),
+          RTPTransceiver.id(),
+          RTPTransceiver.direction()
+        ) :: :ok | {:error, term()}
+  def set_transceiver_direction(peer_connection, transceiver_id, direction)
+      when direction in [:sendrecv, :sendonly, :recvonly, :inactive] do
+    GenServer.call(peer_connection, {:set_transceiver_direction, transceiver_id, direction})
+  end
+
+  @doc """
+  Stops the transceiver specified by the `id`.
+
+  For more information, refer to the [RTCRtpTransceiver: stop() method](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver/stop).
+  """
+  @spec stop_transceiver(peer_connection(), RTPTransceiver.id()) :: :ok | {:error, term()}
+  def stop_transceiver(peer_connection, transceiver_id) do
+    GenServer.call(peer_connection, {:stop_transceiver, transceiver_id})
+  end
+
+  @doc """
+  Adds a new track.
+
+  For more information, refer to the [RTCPeerConnection: addTrack() method](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addTrack).
+  """
+  @spec add_track(peer_connection(), MediaStreamTrack.t()) :: {:ok, RTPSender.t()}
+  def add_track(peer_connection, track) do
+    GenServer.call(peer_connection, {:add_track, track})
+  end
+
+  @doc """
+  Replaces the track assigned to the sender specified by the `sender_id`.
+
+  For more information, refer to the [RTCRtpSender: replaceTrack() method](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/replaceTrack).
+  """
+  @spec replace_track(peer_connection(), RTPSender.id(), MediaStreamTrack.t()) ::
+          :ok | {:error, term()}
+  def replace_track(peer_connection, sender_id, track) do
+    GenServer.call(peer_connection, {:replace_track, sender_id, track})
+  end
+
+  @doc """
+  Removes the track assigned to the sender specified by the `sender_id`.
+
+  For more information, refer to the [RTCPeerConnection: removeTrack() method](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/removeTrack).
+  """
+  @spec remove_track(peer_connection(), RTPSender.id()) :: :ok | {:error, term()}
+  def remove_track(peer_connection, sender_id) do
+    GenServer.call(peer_connection, {:remove_track, sender_id})
+  end
+
+  @doc """
+  Closes the PeerConnection.
+
+  This function kills the PeerConnection process.
+  For more information, refer to the [RTCPeerConnection: close() method](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/close).
+  """
   @spec close(peer_connection()) :: :ok
   def close(peer_connection) do
     GenServer.stop(peer_connection)
@@ -345,13 +519,13 @@ defmodule ExWebRTC.PeerConnection do
   end
 
   @impl true
-  def handle_call({:create_answer, _options}, _from, %{signaling_state: ss} = state)
+  def handle_call(:create_answer, _from, %{signaling_state: ss} = state)
       when ss not in [:have_remote_offer, :have_local_pranswer] do
     {:reply, {:error, :invalid_state}, state}
   end
 
   @impl true
-  def handle_call({:create_answer, _options}, _from, state) do
+  def handle_call(:create_answer, _from, state) do
     {:offer, remote_offer} = state.pending_remote_desc
 
     {:ok, ice_ufrag, ice_pwd} =
@@ -416,6 +590,13 @@ defmodule ExWebRTC.PeerConnection do
   end
 
   @impl true
+  def handle_call(:get_pending_local_description, _from, state) do
+    candidates = state.ice_transport.get_local_candidates(state.ice_pid)
+    desc = do_get_description(state.current_pending_desc, candidates)
+    {:reply, desc, state}
+  end
+
+  @impl true
   def handle_call(:get_current_local_description, _from, state) do
     candidates = state.ice_transport.get_local_candidates(state.ice_pid)
     desc = do_get_description(state.current_local_desc, candidates)
@@ -435,6 +616,13 @@ defmodule ExWebRTC.PeerConnection do
     desc = state.pending_remote_desc || state.current_remote_desc
     candidates = state.ice_transport.get_remote_candidates(state.ice_pid)
     desc = do_get_description(desc, candidates)
+    {:reply, desc, state}
+  end
+
+  @impl true
+  def handle_call(:get_pending_remote_description, _from, state) do
+    candidates = state.ice_transport.get_local_candidates(state.ice_pid)
+    desc = do_get_description(state.current_remote_desc, candidates)
     {:reply, desc, state}
   end
 
@@ -852,6 +1040,8 @@ defmodule ExWebRTC.PeerConnection do
     if new_ice_state == :connected do
       :ok = DTLSTransport.set_ice_connected(state.dtls_transport)
     end
+
+    notify(state.owner, {:ice_connection_state_change, new_ice_state})
 
     if next_conn_state == :failed do
       Logger.debug("Stopping PeerConnection")

--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -59,7 +59,7 @@ defmodule ExWebRTC.PeerConnection do
   @type signaling_state() :: :stable | :have_local_offer | :have_remote_offer
 
   @typedoc """
-  Messages sent by the the `ExWebRTC.PeerConnection` process to its controlling process.
+  Messages sent by the `ExWebRTC.PeerConnection` process to its controlling process.
 
   Most of the messages match the [RTCPeerConnection events](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection#events),
   except for:
@@ -343,7 +343,7 @@ defmodule ExWebRTC.PeerConnection do
   end
 
   @doc """
-  Sets the direction of transceiver specified by the `id`.
+  Sets the direction of transceiver specified by the `transceiver_id`.
 
   For more information, refer to the [RTCRtpTransceiver: direction property](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver/direction).
   """
@@ -358,7 +358,7 @@ defmodule ExWebRTC.PeerConnection do
   end
 
   @doc """
-  Stops the transceiver specified by the `id`.
+  Stops the transceiver specified by the `transceiver_id`.
 
   For more information, refer to the [RTCRtpTransceiver: stop() method](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver/stop).
   """
@@ -401,7 +401,7 @@ defmodule ExWebRTC.PeerConnection do
   @doc """
   Closes the PeerConnection.
 
-  This function kills the PeerConnection process.
+  This function kills the `peer_connection` process.
   For more information, refer to the [RTCPeerConnection: close() method](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/close).
   """
   @spec close(peer_connection()) :: :ok

--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -329,7 +329,7 @@ defmodule ExWebRTC.PeerConnection do
   end
 
   @doc """
-  Adds a new transceiver to this PeerConnection.
+  Adds a new transceiver.
 
   For more information, refer to the [RTCPeerConnection: addTransceiver() method](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addTransceiver).
   """
@@ -793,7 +793,7 @@ defmodule ExWebRTC.PeerConnection do
 
     state = update_negotiation_needed(state)
 
-    {:reply, {:ok, sender}, state}
+    {:reply, {:ok, RTPSender.to_struct(sender)}, state}
   end
 
   @impl true

--- a/lib/ex_webrtc/rtp_receiver.ex
+++ b/lib/ex_webrtc/rtp_receiver.ex
@@ -8,7 +8,11 @@ defmodule ExWebRTC.RTPReceiver do
   alias ExWebRTC.{MediaStreamTrack, Utils, RTPCodecParameters}
   alias __MODULE__.{NACKGenerator, ReportRecorder}
 
-  @type t() :: %__MODULE__{
+  @type id() :: integer()
+
+  @typedoc false
+  @type receiver() :: %{
+          id: id(),
           track: MediaStreamTrack.t(),
           codec: RTPCodecParameters.t() | nil,
           ssrc: non_neg_integer() | nil,
@@ -19,42 +23,64 @@ defmodule ExWebRTC.RTPReceiver do
           nack_generator: NACKGenerator.t()
         }
 
-  @enforce_keys [:track, :codec, :report_recorder]
-  defstruct [
-              ssrc: nil,
-              bytes_received: 0,
-              packets_received: 0,
-              markers_received: 0,
-              nack_generator: %NACKGenerator{}
-            ] ++ @enforce_keys
+  @typedoc """
+  Struct representing a receiver.
+
+  The fields mostly match these of [RTCRtpReceiver](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpReceiver),
+  except for:
+  * `id` - to uniquely identify the receiver.
+  * `codec` - codec this receiver is expected to receive.
+  """
+  @type t() :: %__MODULE__{
+          id: id(),
+          track: MediaStreamTrack.t(),
+          codec: RTPCodecParameters.t() | nil
+        }
+
+  @enforce_keys [:id, :track, :codec]
+  defstruct @enforce_keys
 
   @doc false
-  @spec new(MediaStreamTrack.t(), RTPCodecParameters.t() | nil) :: t()
+  @spec to_struct(receiver()) :: t()
+  def to_struct(receiver) do
+    receiver
+    |> Map.take([:id, :track, :codec])
+    |> then(&struct!(__MODULE__, &1))
+  end
+
+  @doc false
+  @spec new(MediaStreamTrack.t(), RTPCodecParameters.t() | nil) :: receiver()
   def new(track, codec) do
     report_recorder = %ReportRecorder{
       clock_rate: codec && codec.clock_rate
     }
 
-    %__MODULE__{
+    %{
+      id: Utils.generate_id(),
       track: track,
       codec: codec,
-      report_recorder: report_recorder
+      ssrc: nil,
+      bytes_received: 0,
+      packets_received: 0,
+      markers_received: 0,
+      report_recorder: report_recorder,
+      nack_generator: %NACKGenerator{}
     }
   end
 
   @doc false
-  @spec update(t(), RTPCodecParameters.t() | nil) :: t()
+  @spec update(receiver(), RTPCodecParameters.t() | nil) :: receiver()
   def update(receiver, codec) do
     report_recorder = %ReportRecorder{
       receiver.report_recorder
       | clock_rate: codec && codec.clock_rate
     }
 
-    %__MODULE__{receiver | codec: codec, report_recorder: report_recorder}
+    %{receiver | codec: codec, report_recorder: report_recorder}
   end
 
   @doc false
-  @spec receive_packet(t(), ExRTP.Packet.t(), non_neg_integer()) :: t()
+  @spec receive_packet(receiver(), ExRTP.Packet.t(), non_neg_integer()) :: receiver()
   def receive_packet(receiver, packet, size) do
     if packet.payload_type != receiver.codec.payload_type do
       Logger.warning("Received packet with unexpected payload_type \
@@ -65,7 +91,7 @@ defmodule ExWebRTC.RTPReceiver do
     nack_generator = NACKGenerator.record_packet(receiver.nack_generator, packet)
 
     # TODO assign ssrc when applying local/remote description.
-    %__MODULE__{
+    %{
       receiver
       | ssrc: packet.ssrc,
         bytes_received: receiver.bytes_received + size,
@@ -76,7 +102,8 @@ defmodule ExWebRTC.RTPReceiver do
     }
   end
 
-  @spec receive_rtx(t(), ExRTP.Packet.t(), non_neg_integer()) :: {:ok, ExRTP.Packet.t()} | :error
+  @spec receive_rtx(receiver(), ExRTP.Packet.t(), non_neg_integer()) ::
+          {:ok, ExRTP.Packet.t()} | :error
   def receive_rtx(receiver, rtx_packet, apt) do
     with <<seq_no::16, rest::binary>> <- rtx_packet.payload,
          ssrc when ssrc != nil <- receiver.ssrc do
@@ -94,23 +121,24 @@ defmodule ExWebRTC.RTPReceiver do
     end
   end
 
-  @spec receive_report(t(), ExRTCP.Packet.SenderReport.t()) :: t()
+  @spec receive_report(receiver(), ExRTCP.Packet.SenderReport.t()) :: receiver()
   def receive_report(receiver, report) do
     report_recorder = ReportRecorder.record_report(receiver.report_recorder, report)
 
-    %__MODULE__{receiver | report_recorder: report_recorder}
+    %{receiver | report_recorder: report_recorder}
   end
 
   @doc false
-  @spec update_sender_ssrc(t(), non_neg_integer()) :: t()
+  @spec update_sender_ssrc(receiver(), non_neg_integer()) :: receiver()
   def update_sender_ssrc(receiver, ssrc) do
     report_recorder = %ReportRecorder{receiver.report_recorder | sender_ssrc: ssrc}
     nack_generator = %NACKGenerator{receiver.nack_generator | sender_ssrc: ssrc}
-    %__MODULE__{receiver | report_recorder: report_recorder, nack_generator: nack_generator}
+
+    %{receiver | report_recorder: report_recorder, nack_generator: nack_generator}
   end
 
   @doc false
-  @spec get_stats(t(), non_neg_integer()) :: map()
+  @spec get_stats(receiver(), non_neg_integer()) :: map()
   def get_stats(receiver, timestamp) do
     %{
       id: receiver.track.id,

--- a/lib/ex_webrtc/rtp_receiver/nack_generator.ex
+++ b/lib/ex_webrtc/rtp_receiver/nack_generator.ex
@@ -1,5 +1,5 @@
 defmodule ExWebRTC.RTPReceiver.NACKGenerator do
-  @moduledoc nil
+  @moduledoc false
   # for now, it mimics the Pion implementation, but there's some issues and remarks
   # 1) NACKs are send at constant interval
   # 2) no timing rules (like rtt) are taken into account
@@ -25,9 +25,6 @@ defmodule ExWebRTC.RTPReceiver.NACKGenerator do
             last_sn: nil,
             max_nack: @max_nack
 
-  @doc """
-  Records incoming RTP Packet.
-  """
   @spec record_packet(t(), ExRTP.Packet.t()) :: t()
   def record_packet(generator, packet)
 

--- a/lib/ex_webrtc/rtp_receiver/report_recorder.ex
+++ b/lib/ex_webrtc/rtp_receiver/report_recorder.ex
@@ -39,7 +39,11 @@ defmodule ExWebRTC.RTPReceiver.ReportRecorder do
             jitter: 0.0,
             total_lost: 0
 
-  # `time` parameter accepts output of `System.monotonic_time()` as a value.
+  @doc """
+  Record incoming RTP packet.
+
+  `time` parameter accepts output of `System.monotonic_time()` as a value.
+  """
   @spec record_packet(t(), ExRTP.Packet.t(), integer()) :: t()
   def record_packet(recorder, packet, time \\ System.monotonic_time())
 
@@ -63,7 +67,11 @@ defmodule ExWebRTC.RTPReceiver.ReportRecorder do
     |> record_jitter(packet.timestamp, time)
   end
 
-  # `time` parameter accepts output of `System.monotonic_time()` as a value.
+  @doc """
+  Record incoming RTCP Sender Report.
+
+  `time` parameter accepts output of `System.monotonic_time()` as a value.
+  """
   @spec record_report(t(), ExRTCP.Packet.SenderReport.t(), integer()) :: t()
   def record_report(recorder, sender_report, time \\ System.monotonic_time()) do
     # we take the middle 32 bits of the NTP timestamp
@@ -72,7 +80,11 @@ defmodule ExWebRTC.RTPReceiver.ReportRecorder do
     %__MODULE__{recorder | last_sr_ntp_timestamp: ntp_ts, last_sr_timestamp: time}
   end
 
-  # `time` parameter accepts output of `System.monotonic_time()` as a value.
+  @doc """
+  Generate RTCP Receiver Report.
+
+  `time` parameter accepts output of `System.monotonic_time()` as a value.
+  """
   @spec get_report(t(), integer()) :: {:ok, ReceiverReport.t(), t()} | {:error, term()}
   def get_report(recorder, time \\ System.monotonic_time())
 

--- a/lib/ex_webrtc/rtp_receiver/report_recorder.ex
+++ b/lib/ex_webrtc/rtp_receiver/report_recorder.ex
@@ -40,7 +40,7 @@ defmodule ExWebRTC.RTPReceiver.ReportRecorder do
             total_lost: 0
 
   @doc """
-  Record incoming RTP packet.
+  Records incoming RTP packet.
 
   `time` parameter accepts output of `System.monotonic_time()` as a value.
   """
@@ -68,7 +68,7 @@ defmodule ExWebRTC.RTPReceiver.ReportRecorder do
   end
 
   @doc """
-  Record incoming RTCP Sender Report.
+  Records incoming RTCP Sender Report.
 
   `time` parameter accepts output of `System.monotonic_time()` as a value.
   """
@@ -81,7 +81,7 @@ defmodule ExWebRTC.RTPReceiver.ReportRecorder do
   end
 
   @doc """
-  Generate RTCP Receiver Report.
+  Generates RTCP Receiver Report.
 
   `time` parameter accepts output of `System.monotonic_time()` as a value.
   """

--- a/lib/ex_webrtc/rtp_receiver/report_recorder.ex
+++ b/lib/ex_webrtc/rtp_receiver/report_recorder.ex
@@ -1,5 +1,5 @@
 defmodule ExWebRTC.RTPReceiver.ReportRecorder do
-  @moduledoc nil
+  @moduledoc false
   # based on https://datatracker.ietf.org/doc/html/rfc3550#section-6.4.1
 
   import Bitwise
@@ -39,10 +39,7 @@ defmodule ExWebRTC.RTPReceiver.ReportRecorder do
             jitter: 0.0,
             total_lost: 0
 
-  @doc """
-  Records incoming RTP Packet.
-  `time` parameter accepts output of `System.monotonic_time()` as a value.
-  """
+  # `time` parameter accepts output of `System.monotonic_time()` as a value.
   @spec record_packet(t(), ExRTP.Packet.t(), integer()) :: t()
   def record_packet(recorder, packet, time \\ System.monotonic_time())
 
@@ -66,10 +63,7 @@ defmodule ExWebRTC.RTPReceiver.ReportRecorder do
     |> record_jitter(packet.timestamp, time)
   end
 
-  @doc """
-  Records incoming RTCP Sender Report.
-  `time` parameter accepts output of `System.monotonic_time()` as a value.
-  """
+  # `time` parameter accepts output of `System.monotonic_time()` as a value.
   @spec record_report(t(), ExRTCP.Packet.SenderReport.t(), integer()) :: t()
   def record_report(recorder, sender_report, time \\ System.monotonic_time()) do
     # we take the middle 32 bits of the NTP timestamp
@@ -78,10 +72,7 @@ defmodule ExWebRTC.RTPReceiver.ReportRecorder do
     %__MODULE__{recorder | last_sr_ntp_timestamp: ntp_ts, last_sr_timestamp: time}
   end
 
-  @doc """
-  Creates an RTCP Receiver Report.
-  `time` parameter accepts output of `System.monotonic_time()` as a value.
-  """
+  # `time` parameter accepts output of `System.monotonic_time()` as a value.
   @spec get_report(t(), integer()) :: {:ok, ReceiverReport.t(), t()} | {:error, term()}
   def get_report(recorder, time \\ System.monotonic_time())
 

--- a/lib/ex_webrtc/rtp_sender/nack_responder.ex
+++ b/lib/ex_webrtc/rtp_sender/nack_responder.ex
@@ -1,5 +1,5 @@
 defmodule ExWebRTC.RTPSender.NACKResponder do
-  @moduledoc nil
+  @moduledoc false
 
   alias ExRTP.Packet
   alias ExRTCP.Packet.TransportFeedback.NACK
@@ -14,7 +14,6 @@ defmodule ExWebRTC.RTPSender.NACKResponder do
   defstruct packets: %{},
             seq_no: Enum.random(0..0xFFFF)
 
-  @doc false
   @spec record_packet(t(), Packet.t()) :: t()
   def record_packet(responder, packet) do
     key = rem(packet.sequence_number, @max_packets)
@@ -23,7 +22,6 @@ defmodule ExWebRTC.RTPSender.NACKResponder do
     %__MODULE__{responder | packets: packets}
   end
 
-  @doc false
   @spec get_rtx(t(), NACK.t()) :: {[ExRTP.Packet.t()], t()}
   def get_rtx(responder, nack) do
     seq_nos = NACK.to_sequence_numbers(nack)

--- a/lib/ex_webrtc/rtp_sender/report_recorder.ex
+++ b/lib/ex_webrtc/rtp_sender/report_recorder.ex
@@ -1,5 +1,5 @@
 defmodule ExWebRTC.RTPSender.ReportRecorder do
-  @moduledoc nil
+  @moduledoc false
 
   import Bitwise
 
@@ -29,10 +29,7 @@ defmodule ExWebRTC.RTPSender.ReportRecorder do
             packet_count: 0,
             octet_count: 0
 
-  @doc """
-  Records outgoing RTP Packet.
-  `time` parameter accepts output of `System.os_time(:native)` as a value (UNIX timestamp in :native units).
-  """
+  # `time` parameter accepts output of `System.os_time(:native)` as a value (UNIX timestamp in :native units).
   @spec record_packet(t(), ExRTP.Packet.t(), integer()) :: t()
   def record_packet(recorder, packet, time \\ System.os_time(:native))
 
@@ -80,13 +77,9 @@ defmodule ExWebRTC.RTPSender.ReportRecorder do
     }
   end
 
-  @doc """
-  Creates an RTCP Sender Report.
-  `time` parameter accepts output of `System.os_time(:native)` as a value (UNIX timestamp in :native units).
-
-  This function can be called only if at least one packet has been recorded,
-  otherwise it will raise.
-  """
+  # `time` parameter accepts output of `System.os_time(:native)` as a value (UNIX timestamp in :native units).
+  # This function can be called only if at least one packet has been recorded,
+  # otherwise it will raise.
   @spec get_report(t(), integer()) :: {:ok, SenderReport.t(), t()} | {:error, term()}
   def get_report(recorder, time \\ System.os_time(:native))
 

--- a/lib/ex_webrtc/rtp_sender/report_recorder.ex
+++ b/lib/ex_webrtc/rtp_sender/report_recorder.ex
@@ -29,7 +29,11 @@ defmodule ExWebRTC.RTPSender.ReportRecorder do
             packet_count: 0,
             octet_count: 0
 
-  # `time` parameter accepts output of `System.os_time(:native)` as a value (UNIX timestamp in :native units).
+  @doc """
+  Records incoming RTP packet.
+
+  `time` parameter accepts output of `System.os_time(:native)` as a value (UNIX timestamp in :native units).
+  """
   @spec record_packet(t(), ExRTP.Packet.t(), integer()) :: t()
   def record_packet(recorder, packet, time \\ System.os_time(:native))
 
@@ -77,9 +81,13 @@ defmodule ExWebRTC.RTPSender.ReportRecorder do
     }
   end
 
-  # `time` parameter accepts output of `System.os_time(:native)` as a value (UNIX timestamp in :native units).
-  # This function can be called only if at least one packet has been recorded,
-  # otherwise it will raise.
+  @doc """
+  Generates a RTCP Sender Report.
+
+  `time` parameter accepts output of `System.os_time(:native)` as a value (UNIX timestamp in :native units).
+  This function can be called only if at least one packet has been recorded,
+  otherwise it will raise.
+  """
   @spec get_report(t(), integer()) :: {:ok, SenderReport.t(), t()} | {:error, term()}
   def get_report(recorder, time \\ System.os_time(:native))
 

--- a/lib/ex_webrtc/rtp_transceiver.ex
+++ b/lib/ex_webrtc/rtp_transceiver.ex
@@ -67,6 +67,8 @@ defmodule ExWebRTC.RTPTransceiver do
           current_direction: direction() | nil,
           direction: direction(),
           mid: String.t() | nil,
+          stopping: boolean(),
+          stopped: boolean(),
           receiver: RTPReceiver.t(),
           sender: RTPSender.t(),
           rtp_hdr_exts: [ExSDP.Attribute.Extmap.t()],
@@ -79,6 +81,8 @@ defmodule ExWebRTC.RTPTransceiver do
     :direction,
     :current_direction,
     :mid,
+    :stopping,
+    :stopped,
     :receiver,
     :sender,
     :rtp_hdr_exts,
@@ -93,7 +97,17 @@ defmodule ExWebRTC.RTPTransceiver do
     receiver = RTPReceiver.to_struct(transceiver.receiver)
 
     transceiver
-    |> Map.take([:id, :kind, :direction, :current_direction, :mid, :rtp_hdr_exts, :codecs])
+    |> Map.take([
+      :id,
+      :kind,
+      :direction,
+      :current_direction,
+      :mid,
+      :rtp_hdr_exts,
+      :codecs,
+      :stopping,
+      :stopped
+    ])
     |> Map.merge(%{sender: sender, receiver: receiver})
     |> then(&struct!(__MODULE__, &1))
   end


### PR DESCRIPTION
This PR:
- removes most of the stuff that should be private from `RTPTransceiver`, `RTPSender` and `RTPReceiver` structs (like the "recorder..." modules)
- adds some getters to the `PeerConnection` (for the various states)
- adds doc stubs to most of the function in the API in general