### PR TITLE
Fix send_rtp for non-existing track id

### DIFF
--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -997,6 +997,8 @@ defmodule ExWebRTC.PeerConnection do
           "Attempted to send packet to track with unrecognized id: #{inspect(track_id)}"
         )
 
+        {:stop, :invalid_track_id, state}
+
       {transceiver, idx} ->
         {packet, state} =
           case Map.fetch(state.config.video_rtp_hdr_exts, @twcc_uri) do
@@ -1022,8 +1024,6 @@ defmodule ExWebRTC.PeerConnection do
 
         transceivers = List.replace_at(state.transceivers, idx, transceiver)
         state = %{state | transceivers: transceivers}
-
-        {:noreply, state}
 
         {:noreply, state}
     end
@@ -1256,6 +1256,7 @@ defmodule ExWebRTC.PeerConnection do
     Logger.debug("Closing peer connection with reason: #{inspect(reason)}")
     :ok = DTLSTransport.stop(state.dtls_transport)
     :ok = state.ice_transport.stop(state.ice_pid)
+    reason
   end
 
   defp generate_offer_mlines(%{current_local_desc: nil} = state, opts) do

--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -988,8 +988,11 @@ defmodule ExWebRTC.PeerConnection do
     state.transceivers
     |> Stream.with_index()
     |> Enum.find(fn
-      {%{sender: %{track: %{id: id}}}, _idx} -> id == track_id
-      _ -> false
+      {%{sender: %{track: %{id: id}}}, _idx} ->
+        id == track_id
+
+      _ ->
+        false
     end)
     |> case do
       nil ->

--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -984,21 +984,20 @@ defmodule ExWebRTC.PeerConnection do
 
     # TODO: iterating over transceivers is not optimal
     # but this is, most likely, going to be refactored anyways
-    {transceiver, idx} =
-      state.transceivers
-      |> Stream.with_index()
-      |> Enum.find(fn
-        {%{sender: %{track: %{id: id}}}, _idx} -> id == track_id
-        _ -> false
-      end)
 
-    case transceiver do
+    state.transceivers
+    |> Stream.with_index()
+    |> Enum.find(fn
+      {%{sender: %{track: %{id: id}}}, _idx} -> id == track_id
+      _ -> false
+    end)
+    |> case do
       nil ->
         Logger.warning(
           "Attempted to send packet to track with unrecognized id: #{inspect(track_id)}"
         )
 
-      _other ->
+      {transceiver, idx} ->
         {packet, state} =
           case Map.fetch(state.config.video_rtp_hdr_exts, @twcc_uri) do
             {:ok, %{id: id}} ->

--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -984,23 +984,25 @@ defmodule ExWebRTC.PeerConnection do
 
     # TODO: iterating over transceivers is not optimal
     # but this is, most likely, going to be refactored anyways
+    tr_idx =
+      state.transceivers
+      |> Stream.with_index()
+      |> Enum.find(fn
+        {%{sender: %{track: %{id: id}}}, _idx} ->
+          id == track_id
 
-    state.transceivers
-    |> Stream.with_index()
-    |> Enum.find(fn
-      {%{sender: %{track: %{id: id}}}, _idx} ->
-        id == track_id
+        _ ->
+          false
+      end)
 
-      _ ->
-        false
-    end)
-    |> case do
+    case tr_idx do
       nil ->
-        Logger.warning(
-          "Attempted to send packet to track with unrecognized id: #{inspect(track_id)}"
-        )
+        Logger.warning("""
+        Attempted to send packet to track with unrecognized id: #{inspect(track_id)}. \
+        Ignoring.\
+        """)
 
-        {:stop, :invalid_track_id, state}
+        {:noreply, state}
 
       {transceiver, idx} ->
         {packet, state} =
@@ -1259,7 +1261,6 @@ defmodule ExWebRTC.PeerConnection do
     Logger.debug("Closing peer connection with reason: #{inspect(reason)}")
     :ok = DTLSTransport.stop(state.dtls_transport)
     :ok = state.ice_transport.stop(state.ice_pid)
-    reason
   end
 
   defp generate_offer_mlines(%{current_local_desc: nil} = state, opts) do

--- a/test/ex_webrtc/peer_connection_test.exs
+++ b/test/ex_webrtc/peer_connection_test.exs
@@ -215,6 +215,32 @@ defmodule ExWebRTC.PeerConnectionTest do
     assert_receive {:ex_webrtc, _pid, {:connection_state_change, :new}}
   end
 
+  test "send_rtp/4" do
+    {:ok, pc1} = PeerConnection.start_link()
+    {:ok, pc2} = PeerConnection.start_link()
+    track = MediaStreamTrack.new(:audio)
+    {:ok, _sender} = PeerConnection.add_track(pc1, track)
+    :ok = negotiate(pc1, pc2)
+    :ok = connect(pc1, pc2)
+
+    payload = <<3, 2, 5>>
+    packet = ExRTP.Packet.new(payload)
+
+    # Try to send data using correct track id.
+    # Assert that pc2 received this data and send_rtp didn't modify some of the fields.
+    :ok = PeerConnection.send_rtp(pc1, track.id, packet)
+    assert_receive {:ex_webrtc, ^pc2, {:rtp, _track_id, recv_packet}}
+    assert recv_packet.payload == packet.payload
+    assert recv_packet.sequence_number == packet.sequence_number
+    assert recv_packet.timestamp == packet.timestamp
+
+    # Try to send data using invalid track id.
+    # Assert that pc1 is still alive and pc2 didn't receive this data.
+    :ok = PeerConnection.send_rtp(pc1, track.id + 1, packet)
+    assert Process.alive?(pc1) == true
+    refute_receive {:ex_webrtc, ^pc2, {:rtp, _track_id, _packet}}
+  end
+
   test "get_all_running/0" do
     {:ok, pc1} = PeerConnection.start()
     {:ok, pc2} = PeerConnection.start()
@@ -1004,57 +1030,10 @@ defmodule ExWebRTC.PeerConnectionTest do
 
       test_send_data(pc1, pc2, track1, track2)
     end
-
-    test "bad packet id" do
-      # setup track pc1 -> pc2
-      {:ok, pc1} = PeerConnection.start_link()
-      {:ok, pc2} = PeerConnection.start_link()
-      track1 = MediaStreamTrack.new(:audio)
-      {:ok, _sender} = PeerConnection.add_track(pc1, track1)
-      :ok = negotiate(pc1, pc2)
-
-      # setup track pc2 -> pc1
-      track2 = MediaStreamTrack.new(:audio)
-      {:ok, _sender} = PeerConnection.add_track(pc2, track2)
-      :ok = negotiate(pc2, pc1)
-      test_send_bad_rtp(pc1, pc2, track1)
-    end
-  end
-
-  defp test_send_bad_rtp(pc1, pc2, track1) do
-    assert_receive {:ex_webrtc, ^pc1, {:ice_candidate, candidate}}
-    :ok = PeerConnection.add_ice_candidate(pc2, candidate)
-    assert_receive {:ex_webrtc, ^pc2, {:ice_candidate, candidate}}
-    :ok = PeerConnection.add_ice_candidate(pc1, candidate)
-
-    # wait to establish connection
-    assert_receive {:ex_webrtc, ^pc1, {:connection_state_change, :connected}}, 1000
-    assert_receive {:ex_webrtc, ^pc2, {:connection_state_change, :connected}}, 1000
-
-    # receive track info
-    assert_receive {:ex_webrtc, ^pc1, {:track, %MediaStreamTrack{kind: :audio, id: _id1}}}
-    assert_receive {:ex_webrtc, ^pc2, {:track, %MediaStreamTrack{kind: :audio, id: _id2}}}
-
-    payload = <<3, 2, 5>>
-    packet = ExRTP.Packet.new(payload)
-
-    Process.flag(:trap_exit, true)
-    :ok = PeerConnection.send_rtp(pc2, track1.id, packet)
-
-    assert_receive {:EXIT, ^pc2, :invalid_track_id}
-    Process.flag(:trap_exit, false)
   end
 
   defp test_send_data(pc1, pc2, track1, track2) do
-    # exchange ICE candidates
-    assert_receive {:ex_webrtc, ^pc1, {:ice_candidate, candidate}}
-    :ok = PeerConnection.add_ice_candidate(pc2, candidate)
-    assert_receive {:ex_webrtc, ^pc2, {:ice_candidate, candidate}}
-    :ok = PeerConnection.add_ice_candidate(pc1, candidate)
-
-    # wait to establish connection
-    assert_receive {:ex_webrtc, ^pc1, {:connection_state_change, :connected}}, 1000
-    assert_receive {:ex_webrtc, ^pc2, {:connection_state_change, :connected}}, 1000
+    assert :ok = connect(pc1, pc2)
 
     # receive track info
     assert_receive {:ex_webrtc, ^pc1, {:track, %MediaStreamTrack{kind: :audio, id: id1}}}
@@ -1209,5 +1188,19 @@ defmodule ExWebRTC.PeerConnectionTest do
     # make sure there was only one negotiation_needed fired
     refute_receive {:ex_webrtc, ^pc1, :negotiation_needed}
     refute_receive {:ex_webrtc, ^pc2, :negotiation_needed}, 0
+  end
+
+  defp connect(pc1, pc2) do
+    # exchange ICE candidates
+    assert_receive {:ex_webrtc, ^pc1, {:ice_candidate, candidate}}
+    :ok = PeerConnection.add_ice_candidate(pc2, candidate)
+    assert_receive {:ex_webrtc, ^pc2, {:ice_candidate, candidate}}
+    :ok = PeerConnection.add_ice_candidate(pc1, candidate)
+
+    # wait to establish connection
+    assert_receive {:ex_webrtc, ^pc1, {:connection_state_change, :connected}}, 1000
+    assert_receive {:ex_webrtc, ^pc2, {:connection_state_change, :connected}}, 1000
+
+    :ok
   end
 end

--- a/test/ex_webrtc/peer_connection_test.exs
+++ b/test/ex_webrtc/peer_connection_test.exs
@@ -1005,7 +1005,7 @@ defmodule ExWebRTC.PeerConnectionTest do
       test_send_data(pc1, pc2, track1, track2)
     end
 
-    test "bad" do
+    test "bad packet id" do
       # setup track pc1 -> pc2
       {:ok, pc1} = PeerConnection.start_link()
       {:ok, pc2} = PeerConnection.start_link()
@@ -1041,7 +1041,7 @@ defmodule ExWebRTC.PeerConnectionTest do
     Process.flag(:trap_exit, true)
     :ok = PeerConnection.send_rtp(pc2, track1.id, packet)
 
-    assert_receive {:EXIT, ^pc2, :bad_track_id}
+    assert_receive {:EXIT, ^pc2, :invalid_track_id}
     Process.flag(:trap_exit, false)
   end
 


### PR DESCRIPTION
I did not returned a `{:stop, :unrecognized_id, state}` as I don't know how you want to treat this.