### PR TITLE
Fix `set_remote_description` failing on description with rejected m-lines

### DIFF
--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -1427,10 +1427,10 @@ defmodule ExWebRTC.PeerConnection do
 
         {ice_ufrag, ice_pwd} ->
           :ok = state.ice_transport.set_remote_credentials(state.ice_pid, ice_ufrag, ice_pwd)
-      end
 
-      for candidate <- SDPUtils.get_ice_candidates(sdp) do
-        state.ice_transport.add_remote_candidate(state.ice_pid, candidate)
+          for candidate <- SDPUtils.get_ice_candidates(sdp) do
+            state.ice_transport.add_remote_candidate(state.ice_pid, candidate)
+          end
       end
 
       state =

--- a/lib/ex_webrtc/sdp_utils.ex
+++ b/lib/ex_webrtc/sdp_utils.ex
@@ -24,7 +24,7 @@ defmodule ExWebRTC.SDPUtils do
     end
   end
 
-  def ensure_mid(sdp) do
+  defp ensure_mid(sdp) do
     sdp.media
     |> Enum.reduce_while({:ok, []}, fn media, {:ok, acc} ->
       case ExSDP.get_attributes(media, :mid) do
@@ -39,7 +39,7 @@ defmodule ExWebRTC.SDPUtils do
     end
   end
 
-  def ensure_bundle(sdp) do
+  defp ensure_bundle(sdp) do
     groups = ExSDP.get_attributes(sdp, ExSDP.Attribute.Group)
 
     mline_mids = get_bundle_mids(sdp.media)
@@ -64,7 +64,7 @@ defmodule ExWebRTC.SDPUtils do
     Enum.filter(groups, fn %ExSDP.Attribute.Group{semantics: name} -> name == to_filter end)
   end
 
-  def ensure_rtcp_mux(sdp) do
+  defp ensure_rtcp_mux(sdp) do
     sdp.media
     |> Enum.all?(&(ExSDP.get_attribute(&1, :rtcp_mux) == :rtcp_mux))
     |> case do

--- a/lib/ex_webrtc/sdp_utils.ex
+++ b/lib/ex_webrtc/sdp_utils.ex
@@ -18,9 +18,10 @@ defmodule ExWebRTC.SDPUtils do
   end
 
   defp ensure_non_empty(sdp) do
-    case length(sdp.media) do
-      0 -> {:error, :empty_sdp}
-      _other -> :ok
+    if Enum.empty?(sdp.media) do
+      {:error, :empty_sdp}
+    else
+      :ok
     end
   end
 

--- a/lib/ex_webrtc/sdp_utils.ex
+++ b/lib/ex_webrtc/sdp_utils.ex
@@ -135,7 +135,7 @@ defmodule ExWebRTC.SDPUtils do
     mline_creds =
       sdp.media
       |> Enum.reject(&rejected?/1)
-      |> Enum.map(fn mline -> do_get_ice_credentials(mline) end)
+      |> Enum.map(&do_get_ice_credentials/1)
 
     case {session_creds, mline_creds} do
       # no session creds and no mlines (empty SDP)

--- a/lib/ex_webrtc/sdp_utils.ex
+++ b/lib/ex_webrtc/sdp_utils.ex
@@ -8,7 +8,22 @@ defmodule ExWebRTC.SDPUtils do
 
   @type extension() :: {Extension.SourceDescription, atom()}
 
-  @spec ensure_mid(ExSDP.t()) :: :ok | {:error, :missing_mid | :duplicated_mid}
+  @spec ensure_valid(ExSDP.t()) :: :ok | {:error, term()}
+  def ensure_valid(sdp) do
+    with :ok <- ensure_non_empty(sdp),
+         :ok <- ensure_mid(sdp),
+         :ok <- ensure_bundle(sdp) do
+      ensure_rtcp_mux(sdp)
+    end
+  end
+
+  defp ensure_non_empty(sdp) do
+    case length(sdp.media) do
+      0 -> {:error, :empty_sdp}
+      _other -> :ok
+    end
+  end
+
   def ensure_mid(sdp) do
     sdp.media
     |> Enum.reduce_while({:ok, []}, fn media, {:ok, acc} ->
@@ -24,13 +39,6 @@ defmodule ExWebRTC.SDPUtils do
     end
   end
 
-  @spec ensure_bundle(ExSDP.t()) ::
-          :ok
-          | {:error,
-             :non_exhaustive_bundle_group
-             | :missing_bundle_group
-             | :multiple_bundle_groups
-             | :invalid_bundle_group}
   def ensure_bundle(sdp) do
     groups = ExSDP.get_attributes(sdp, ExSDP.Attribute.Group)
 
@@ -56,7 +64,6 @@ defmodule ExWebRTC.SDPUtils do
     Enum.filter(groups, fn %ExSDP.Attribute.Group{semantics: name} -> name == to_filter end)
   end
 
-  @spec ensure_rtcp_mux(ExSDP.t()) :: :ok | {:error, :missing_rtcp_mux}
   def ensure_rtcp_mux(sdp) do
     sdp.media
     |> Enum.all?(&(ExSDP.get_attribute(&1, :rtcp_mux) == :rtcp_mux))
@@ -116,7 +123,7 @@ defmodule ExWebRTC.SDPUtils do
   end
 
   @spec get_ice_credentials(ExSDP.t()) ::
-          {:ok, {binary(), binary()}}
+          {:ok, {binary(), binary()} | nil}
           | {:error,
              :missing_ice_pwd
              | :missing_ice_ufrag
@@ -124,12 +131,16 @@ defmodule ExWebRTC.SDPUtils do
              | :conflicting_ice_credentials}
   def get_ice_credentials(sdp) do
     session_creds = do_get_ice_credentials(sdp)
-    mline_creds = Enum.map(sdp.media, fn mline -> do_get_ice_credentials(mline) end)
+
+    mline_creds =
+      sdp.media
+      |> Enum.reject(&rejected?/1)
+      |> Enum.map(fn mline -> do_get_ice_credentials(mline) end)
 
     case {session_creds, mline_creds} do
       # no session creds and no mlines (empty SDP)
       {{nil, nil}, []} ->
-        {:error, :missing_ice_credentials}
+        {:ok, nil}
 
       # session creds but no mlines (empty SDP)
       {session_creds, []} ->

--- a/test/ex_webrtc/peer_connection_test.exs
+++ b/test/ex_webrtc/peer_connection_test.exs
@@ -467,6 +467,62 @@ defmodule ExWebRTC.PeerConnectionTest do
         assert expected_result == PeerConnection.set_remote_description(pc, offer)
       end)
     end
+
+    test "mline rejected" do
+      {:ok, pc} = PeerConnection.start_link()
+
+      {:ok, _sender} = PeerConnection.add_track(pc, MediaStreamTrack.new(:video))
+      {:ok, _sender} = PeerConnection.add_track(pc, MediaStreamTrack.new(:audio))
+      {:ok, offer} = PeerConnection.create_offer(pc)
+      :ok = PeerConnection.set_local_description(pc, offer)
+
+      # first m-line is rejected = ice ufrag and passwd are random (thats what Chromium seems to do)
+      sdp =
+        """
+        v=0
+        o=- 4455712322662451611 2 IN IP4 127.0.0.1
+        s=-
+        t=0 0
+        a=group:BUNDLE 1
+        a=extmap-allow-mixed
+        a=msid-semantic: WMS
+        m=video 0 UDP/TLS/RTP/SAVPF 0
+        c=IN IP4 0.0.0.0
+        a=rtcp:9 IN IP4 0.0.0.0
+        a=ice-ufrag:oIRa
+        a=ice-pwd:10rPa8NrMCm602mt1OVkUHJs
+        a=ice-options:trickle
+        a=fingerprint:sha-256 C8:06:34:28:7C:5B:55:00:42:61:54:D2:84:29:B5:07:3D:9A:6C:5C:C6:79:B1:B0:A8:12:30:AD:26:36:93:45
+        a=setup:active
+        a=mid:0
+        a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+        a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
+        a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
+        a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
+        a=sendonly
+        a=rtcp-mux
+        m=audio 9 UDP/TLS/RTP/SAVPF 111
+        c=IN IP4 0.0.0.0
+        a=rtcp:9 IN IP4 0.0.0.0
+        a=ice-ufrag:Anyh
+        a=ice-pwd:cdaU0jbHlOTf98BNTRoZxMo1
+        a=ice-options:trickle
+        a=fingerprint:sha-256 C8:06:34:28:7C:5B:55:00:42:61:54:D2:84:29:B5:07:3D:9A:6C:5C:C6:79:B1:B0:A8:12:30:AD:26:36:93:45
+        a=setup:active
+        a=mid:1
+        a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+        a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
+        a=recvonly
+        a=rtcp-mux
+        a=rtpmap:111 opus/48000/2
+        a=rtcp-fb:111 transport-cc
+        a=fmtp:111 minptime=10;useinbandfec=1
+        """
+
+      answer = %SessionDescription{type: :answer, sdp: sdp}
+
+      assert :ok = PeerConnection.set_remote_description(pc, answer)
+    end
   end
 
   describe "add_transceiver/3" do

--- a/test/ex_webrtc/peer_connection_test.exs
+++ b/test/ex_webrtc/peer_connection_test.exs
@@ -495,10 +495,6 @@ defmodule ExWebRTC.PeerConnectionTest do
         a=fingerprint:sha-256 C8:06:34:28:7C:5B:55:00:42:61:54:D2:84:29:B5:07:3D:9A:6C:5C:C6:79:B1:B0:A8:12:30:AD:26:36:93:45
         a=setup:active
         a=mid:0
-        a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
-        a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
-        a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
-        a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
         a=sendonly
         a=rtcp-mux
         m=audio 9 UDP/TLS/RTP/SAVPF 111
@@ -510,8 +506,6 @@ defmodule ExWebRTC.PeerConnectionTest do
         a=fingerprint:sha-256 C8:06:34:28:7C:5B:55:00:42:61:54:D2:84:29:B5:07:3D:9A:6C:5C:C6:79:B1:B0:A8:12:30:AD:26:36:93:45
         a=setup:active
         a=mid:1
-        a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
-        a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
         a=recvonly
         a=rtcp-mux
         a=rtpmap:111 opus/48000/2


### PR DESCRIPTION
Fixes:
- `set_remote_description` won't try to use ICE credentials from rejected m-lines (and subsequently, won't fail if ICE credentials in rejected m-lines differ from credentials in active m-lines),
- `set_remote_description` won't fail when all of the m-lines are rejected (so there's no valid ICE credentials in the description). In such case, it will either not connect (for the first description) or use credentials from previous descriptions (for the subsequent descriptions)

Other elements of rejected m-lines might need to be ignored as well (like MIDs, fingerprints, etc.), but it seems like browsers include them anyway, so for now this fix seems to be enough.

Close #144 