### PR TITLE
Ignore lack of `rtcp_mux` in rejected m-lines

### DIFF
--- a/lib/ex_webrtc/sdp_utils.ex
+++ b/lib/ex_webrtc/sdp_utils.ex
@@ -66,7 +66,9 @@ defmodule ExWebRTC.SDPUtils do
   end
 
   defp ensure_rtcp_mux(sdp) do
+    # Firefox does not add `rtcp_mux` in rejected mlines
     sdp.media
+    |> Enum.reject(&rejected?/1)
     |> Enum.all?(&(ExSDP.get_attribute(&1, :rtcp_mux) == :rtcp_mux))
     |> case do
       true -> :ok

--- a/test/ex_webrtc/peer_connection_test.exs
+++ b/test/ex_webrtc/peer_connection_test.exs
@@ -476,7 +476,9 @@ defmodule ExWebRTC.PeerConnectionTest do
       {:ok, offer} = PeerConnection.create_offer(pc)
       :ok = PeerConnection.set_local_description(pc, offer)
 
-      # first m-line is rejected = ice ufrag and passwd are random (thats what Chromium seems to do)
+      # first m-line is rejected, which means:
+      # - ice ufrag and passwd are random (thats what Chromium seems to do)
+      # - no rtcp_mux (thats what Firefox does)
       sdp =
         """
         v=0
@@ -496,7 +498,6 @@ defmodule ExWebRTC.PeerConnectionTest do
         a=setup:active
         a=mid:0
         a=sendonly
-        a=rtcp-mux
         m=audio 9 UDP/TLS/RTP/SAVPF 111
         c=IN IP4 0.0.0.0
         a=rtcp:9 IN IP4 0.0.0.0


### PR DESCRIPTION
Close #149

The lack of `rtcp_mux` previously caused PeerConnection to raise an error. This PR fixes this.

Be aware that a remote SDP description with all m-lines rejected might still cause PeerConnection to raise.
