### PR TITLE
Hide VP8 and Opus Payloader/Depayloader modules

### DIFF
--- a/examples/send_from_file/lib/send_from_file/peer_handler.ex
+++ b/examples/send_from_file/lib/send_from_file/peer_handler.ex
@@ -60,7 +60,7 @@ defmodule SendFromFile.PeerHandler do
     {:ok, _sender} = PeerConnection.add_track(pc, audio_track)
 
     {:ok, _header, video_reader} = IVF.Reader.open(@video_file)
-    {:ok, video_payloader} = @video_codecs |> hd() |> Payloader.new(800)
+    {:ok, video_payloader} = @video_codecs |> hd() |> Payloader.new(max_payload_size: 800)
 
     {:ok, audio_reader} = Ogg.Reader.open(@audio_file)
     {:ok, audio_payloader} = @audio_codecs |> hd() |> Payloader.new()

--- a/lib/ex_webrtc/rtp/depayloader.ex
+++ b/lib/ex_webrtc/rtp/depayloader.ex
@@ -1,57 +1,41 @@
 defmodule ExWebRTC.RTP.Depayloader do
   @moduledoc """
-  Dispatcher module and behaviour for ExWebRTC Depayloaders.
+  RTP depayloader.
+
+  It unpacks RTP pakcets into audio/video frames.
   """
 
   alias ExWebRTC.RTPCodecParameters
 
-  @type depayloader :: struct()
+  @opaque depayloader :: struct()
 
   @doc """
-  Creates a new depayloader struct.
+  Creates a new depayloader that matches the passed codec parameters.
   """
-  @callback new(options :: any()) :: depayloader()
-
-  @doc """
-  Processes binary data from a single RTP packet, and outputs a frame if assembled.
-
-  Returns the frame (or `nil` if a frame could not be depayloaded yet)
-  together with the updated depayloader struct.
-  """
-  @callback depayload(depayloader(), packet :: ExRTP.Packet.t()) ::
-              {binary() | nil, depayloader()}
-
-  @doc """
-  Creates a new depayloader struct that matches the passed codec parameters.
-
-  Refer to the modules implementing the behaviour for available options.
-  """
-  @spec new(RTPCodecParameters.t(), any()) ::
+  @spec new(RTPCodecParameters.t()) ::
           {:ok, depayloader()} | {:error, :no_depayloader_for_codec}
-  def new(codec_params, options \\ nil) do
-    with {:ok, module} <- match_depayloader_module(codec_params.mime_type) do
-      depayloader = if is_nil(options), do: module.new(), else: module.new(options)
-
+  def new(codec_params) do
+    with {:ok, module} <- to_depayloader_module(codec_params.mime_type) do
+      depayloader = module.new()
       {:ok, depayloader}
     end
   end
 
   @doc """
-  Processes binary data from a single RTP packet using the depayloader's module,
-  and outputs a frame if assembled.
+  Processes binary data from a single RTP packet, and outputs a frame if assembled.
 
   Returns the frame (or `nil` if a frame could not be depayloaded yet)
-  together with the updated depayloader struct.
+  together with the updated depayloader.
   """
   @spec depayload(depayloader(), ExRTP.Packet.t()) :: {binary() | nil, depayloader()}
   def depayload(%module{} = depayloader, packet) do
     module.depayload(depayloader, packet)
   end
 
-  defp match_depayloader_module(mime_type) do
+  defp to_depayloader_module(mime_type) do
     case String.downcase(mime_type) do
-      "video/vp8" -> {:ok, ExWebRTC.RTP.VP8.Depayloader}
-      "audio/opus" -> {:ok, ExWebRTC.RTP.Opus.Depayloader}
+      "video/vp8" -> {:ok, ExWebRTC.RTP.Depayloader.VP8}
+      "audio/opus" -> {:ok, ExWebRTC.RTP.Depayloader.Opus}
       _other -> {:error, :no_depayloader_for_codec}
     end
   end

--- a/lib/ex_webrtc/rtp/depayloader_behaviour.ex
+++ b/lib/ex_webrtc/rtp/depayloader_behaviour.ex
@@ -1,0 +1,19 @@
+defmodule ExWebRTC.RTP.Depayloader.Behaviour do
+  @moduledoc false
+
+  @type depayloader :: struct()
+
+  @doc """
+  Creates a new depayloader struct.
+  """
+  @callback new() :: depayloader()
+
+  @doc """
+  Processes binary data from a single RTP packet, and outputs a frame if assembled.
+
+  Returns the frame (or `nil` if a frame could not be depayloaded yet)
+  together with the updated depayloader struct.
+  """
+  @callback depayload(depayloader(), packet :: ExRTP.Packet.t()) ::
+              {binary() | nil, depayloader()}
+end

--- a/lib/ex_webrtc/rtp/opus/depayloader.ex
+++ b/lib/ex_webrtc/rtp/opus/depayloader.ex
@@ -1,34 +1,23 @@
-defmodule ExWebRTC.RTP.Opus.Depayloader do
-  @moduledoc """
-  Decapsualtes Opus audio out of RTP packet.
-
-  Based on [RFC 7587: RTP Payload Format for the Opus Speech and Audio Codec](https://datatracker.ietf.org/doc/html/rfc7587).
-  """
+defmodule ExWebRTC.RTP.Depayloader.Opus do
+  @moduledoc false
+  # Decapsualtes Opus audio out of RTP packet.
+  #
+  # Based on [RFC 7587: RTP Payload Format for the Opus Speech and Audio Codec](https://datatracker.ietf.org/doc/html/rfc7587).
 
   alias ExRTP.Packet
 
-  @behaviour ExWebRTC.RTP.Depayloader
+  @behaviour ExWebRTC.RTP.Depayloader.Behaviour
 
-  @opaque t :: %__MODULE__{}
+  @type t :: %__MODULE__{}
 
   defstruct []
 
-  @doc """
-  Creates a new Opus depayloader struct.
-
-  Does not take any options/parameters.
-  """
   @impl true
-  @spec new(any()) :: t()
-  def new(_unused \\ nil) do
+  @spec new() :: t()
+  def new() do
     %__MODULE__{}
   end
 
-  @doc """
-  Takes Opus packet out of an RTP packet.
-
-  Always returns a binary as the first element.
-  """
   @impl true
   @spec depayload(t(), Packet.t()) :: {binary(), t()}
   def depayload(%__MODULE__{} = depayloader, %Packet{payload: payload}),

--- a/lib/ex_webrtc/rtp/opus/payloader.ex
+++ b/lib/ex_webrtc/rtp/opus/payloader.ex
@@ -1,33 +1,20 @@
-defmodule ExWebRTC.RTP.Opus.Payloader do
-  @moduledoc """
-  Encapsulates Opus audio packet into an RTP packet.
+defmodule ExWebRTC.RTP.Payloader.Opus do
+  @moduledoc false
+  # Encapsulates Opus audio packet into an RTP packet.
+  #
+  # Based on [RFC 7587: RTP Payload Format for the Opus Speech and Audio Codec](https://datatracker.ietf.org/doc/html/rfc7587).
 
-  Based on [RFC 7587: RTP Payload Format for the Opus Speech and Audio Codec](https://datatracker.ietf.org/doc/html/rfc7587).
-  """
+  @behaviour ExWebRTC.RTP.Payloader.Behaviour
 
-  @behaviour ExWebRTC.RTP.Payloader
-
-  @opaque t :: %__MODULE__{}
+  @type t :: %__MODULE__{}
 
   defstruct []
 
-  @doc """
-  Creates a new Opus payloader struct.
-
-  Does not take any options/parameters.
-  """
   @impl true
-  @spec new(any()) :: t()
-  def new(_unused \\ nil) do
+  def new(_max_payload_size) do
     %__MODULE__{}
   end
 
-  @doc """
-  Packs Opus packet into an RTP packet.
-
-  Fields from RTP header like ssrc, timestamp etc. are set to 0.
-  Always returns a single RTP packet.
-  """
   @impl true
   @spec payload(t(), binary()) :: {[ExRTP.Packet.t()], t()}
   def payload(%__MODULE__{} = payloader, packet) when packet != <<>> do

--- a/lib/ex_webrtc/rtp/payloader.ex
+++ b/lib/ex_webrtc/rtp/payloader.ex
@@ -1,53 +1,43 @@
 defmodule ExWebRTC.RTP.Payloader do
   @moduledoc """
-  Dispatcher module and behaviour for ExWebRTC Payloaders.
+  RTP payloader.
+
+  It packs audio/video frames into one or more RTP packets.
   """
 
   alias ExWebRTC.RTPCodecParameters
 
-  @type payloader :: struct()
+  @opaque payloader :: struct()
 
   @doc """
-  Creates a new payloader struct.
+  Creates a new payloader that matches the passed codec parameters.
+
+  * max_payload_size - determines the maximum size of a single RTP packet outputted by the payloader.
+  It must be greater than `100`, and is set to `1000` by default.
   """
-  @callback new(options :: any()) :: payloader()
-
-  @doc """
-  Packs a frame into one or more RTP packets.
-
-  Returns the packets together with the updated payloader struct.
-  """
-  @callback payload(payloader(), frame :: binary()) :: {[ExRTP.Packet.t()], payloader()}
-
-  @doc """
-  Creates a new payloader struct that matches the passed codec parameters.
-
-  Refer to the modules implementing the behaviour for available options.
-  """
-  @spec new(RTPCodecParameters.t(), any()) ::
+  @spec new(RTPCodecParameters.t(), integer()) ::
           {:ok, payloader()} | {:error, :no_payloader_for_codec}
-  def new(codec_params, options \\ nil) do
-    with {:ok, module} <- match_payloader_module(codec_params.mime_type) do
-      payloader = if is_nil(options), do: module.new(), else: module.new(options)
-
+  def new(codec_params, max_payload_size \\ 1000) do
+    with {:ok, module} <- to_payloader_module(codec_params.mime_type) do
+      payloader = module.new(max_payload_size)
       {:ok, payloader}
     end
   end
 
   @doc """
-  Packs a frame into one or more RTP packets using the payloader's module.
+  Packs a frame into one or more RTP packets.
 
-  Returns the packets together with the updated payloader struct.
+  Returns the packets together with the updated payloader.
   """
   @spec payload(payloader(), binary()) :: {[ExRTP.Packet.t()], payloader()}
   def payload(%module{} = payloader, frame) do
     module.payload(payloader, frame)
   end
 
-  defp match_payloader_module(mime_type) do
+  defp to_payloader_module(mime_type) do
     case String.downcase(mime_type) do
-      "video/vp8" -> {:ok, ExWebRTC.RTP.VP8.Payloader}
-      "audio/opus" -> {:ok, ExWebRTC.RTP.Opus.Payloader}
+      "video/vp8" -> {:ok, ExWebRTC.RTP.Payloader.VP8}
+      "audio/opus" -> {:ok, ExWebRTC.RTP.Payloader.Opus}
       _other -> {:error, :no_payloader_for_codec}
     end
   end

--- a/lib/ex_webrtc/rtp/payloader.ex
+++ b/lib/ex_webrtc/rtp/payloader.ex
@@ -12,13 +12,15 @@ defmodule ExWebRTC.RTP.Payloader do
   @doc """
   Creates a new payloader that matches the passed codec parameters.
 
-  * max_payload_size - determines the maximum size of a single RTP packet outputted by the payloader.
-  It must be greater than `100`, and is set to `1000` by default.
+  Opts:
+    * max_payload_size - determines the maximum size of a single RTP packet outputted by the payloader.
+    It must be greater than `100`, and is set to `1000` by default.
   """
-  @spec new(RTPCodecParameters.t(), integer()) ::
+  @spec new(RTPCodecParameters.t(), max_payload_size: integer()) ::
           {:ok, payloader()} | {:error, :no_payloader_for_codec}
-  def new(codec_params, max_payload_size \\ 1000) do
+  def new(codec_params, opts \\ []) do
     with {:ok, module} <- to_payloader_module(codec_params.mime_type) do
+      max_payload_size = opts[:max_payload_size] || 1000
       payloader = module.new(max_payload_size)
       {:ok, payloader}
     end

--- a/lib/ex_webrtc/rtp/payloader_behaviour.ex
+++ b/lib/ex_webrtc/rtp/payloader_behaviour.ex
@@ -1,0 +1,17 @@
+defmodule ExWebRTC.RTP.Payloader.Behaviour do
+  @moduledoc false
+
+  @type payloader :: struct()
+
+  @doc """
+  Creates a new payloader struct.
+  """
+  @callback new(max_payload_size :: integer()) :: payloader()
+
+  @doc """
+  Packs a frame into one or more RTP packets.
+
+  Returns the packets together with the updated payloader struct.
+  """
+  @callback payload(payloader(), frame :: binary()) :: {[ExRTP.Packet.t()], payloader()}
+end

--- a/lib/ex_webrtc/rtp/vp8/payload.ex
+++ b/lib/ex_webrtc/rtp/vp8/payload.ex
@@ -1,9 +1,8 @@
 defmodule ExWebRTC.RTP.VP8.Payload do
-  @moduledoc """
-  Defines VP8 payload structure stored in RTP packet payload.
-
-  Based on [RFC 7741: RTP Payload Format for VP8 Video](https://datatracker.ietf.org/doc/html/rfc7741).
-  """
+  @moduledoc false
+  # Defines VP8 payload structure stored in RTP packet payload.
+  #
+  # Based on [RFC 7741: RTP Payload Format for VP8 Video](https://datatracker.ietf.org/doc/html/rfc7741).
 
   @type t() :: %__MODULE__{
           n: 0 | 1,

--- a/lib/ex_webrtc/rtp/vp8/payloader.ex
+++ b/lib/ex_webrtc/rtp/vp8/payloader.ex
@@ -1,14 +1,13 @@
-defmodule ExWebRTC.RTP.VP8.Payloader do
-  @moduledoc """
-  Encapsulates VP8 video frames into RTP packets.
+defmodule ExWebRTC.RTP.Payloader.VP8 do
+  @moduledoc false
+  # Encapsulates VP8 video frames into RTP packets.
+  #
+  # Based on [RFC 7741: RTP Payload Format for VP8 Video](https://datatracker.ietf.org/doc/html/rfc7741).
+  #
+  # It does not support `X` bit right now, in particular it
+  # does not pay attention to VP8 partition boundaries (see RFC 7741 sec. 4.4).
 
-  Based on [RFC 7741: RTP Payload Format for VP8 Video](https://datatracker.ietf.org/doc/html/rfc7741).
-
-  It does not support `X` bit right now, in particular it
-  does not pay attention to VP8 partition boundaries (see RFC 7741 sec. 4.4).
-  """
-
-  @behaviour ExWebRTC.RTP.Payloader
+  @behaviour ExWebRTC.RTP.Payloader.Behaviour
 
   @first_chunk_descriptor <<0::1, 0::1, 0::1, 1::1, 0::1, 0::3>>
 
@@ -16,32 +15,19 @@ defmodule ExWebRTC.RTP.VP8.Payloader do
 
   @desc_size_bytes 1
 
-  @opaque t() :: %__MODULE__{
-            max_payload_size: non_neg_integer()
-          }
+  @type t() :: %__MODULE__{
+          max_payload_size: non_neg_integer()
+        }
 
   @enforce_keys [:max_payload_size]
   defstruct @enforce_keys
 
-  @doc """
-  Creates a new VP8 payloader struct.
-
-  The parameter `max_payload_size` determines the maximum size of a single RTP packet
-  outputted by the payloader. It must be greater than `100`, and is set to `1000` by default.
-  """
   @impl true
-  @spec new(non_neg_integer()) :: t()
-  def new(max_payload_size \\ 1000) when max_payload_size > 100 do
+  def new(max_payload_size) when max_payload_size > 100 do
     %__MODULE__{max_payload_size: max_payload_size}
   end
 
-  @doc """
-  Packs VP8 frame into one or more RTP packets.
-
-  Fields from RTP header like ssrc, timestamp etc. are set to 0.
-  """
   @impl true
-  @spec payload(t(), frame :: binary()) :: {[ExRTP.Packet.t()], t()}
   def payload(%__MODULE__{} = payloader, frame) when frame != <<>> do
     rtp_payloads = chunk(frame, payloader.max_payload_size - @desc_size_bytes)
 

--- a/test/ex_webrtc/rtp/depayloader_test.exs
+++ b/test/ex_webrtc/rtp/depayloader_test.exs
@@ -3,7 +3,6 @@ defmodule ExWebRTC.RTP.DepayloaderTest do
 
   alias ExWebRTC.RTPCodecParameters
   alias ExWebRTC.RTP.Depayloader
-  alias ExWebRTC.RTP.{Opus, VP8}
 
   @packet %ExRTP.Packet{
     payload_type: 96,
@@ -19,7 +18,7 @@ defmodule ExWebRTC.RTP.DepayloaderTest do
              |> Depayloader.new()
 
     assert Depayloader.depayload(depayloader, @packet) ==
-             VP8.Depayloader.depayload(depayloader, @packet)
+             Depayloader.VP8.depayload(depayloader, @packet)
   end
 
   test "creates an Opus depayloader and dispatches calls to its module" do
@@ -33,7 +32,7 @@ defmodule ExWebRTC.RTP.DepayloaderTest do
              |> Depayloader.new()
 
     assert Depayloader.depayload(depayloader, @packet) ==
-             Opus.Depayloader.depayload(depayloader, @packet)
+             Depayloader.Opus.depayload(depayloader, @packet)
   end
 
   test "returns error if no depayloader exists for given codec" do

--- a/test/ex_webrtc/rtp/payloader_test.exs
+++ b/test/ex_webrtc/rtp/payloader_test.exs
@@ -3,7 +3,6 @@ defmodule ExWebRTC.RTP.PayloaderTest do
 
   alias ExWebRTC.RTPCodecParameters
   alias ExWebRTC.RTP.Payloader
-  alias ExWebRTC.RTP.{Opus, VP8}
 
   @frame <<0, 1, 2, 3>>
 
@@ -17,7 +16,7 @@ defmodule ExWebRTC.RTP.PayloaderTest do
              %RTPCodecParameters{payload_type: 96, mime_type: "video/VP8", clock_rate: 90_000}
              |> Payloader.new(800)
 
-    assert Payloader.payload(payloader, @frame) == VP8.Payloader.payload(payloader, @frame)
+    assert Payloader.payload(payloader, @frame) == Payloader.VP8.payload(payloader, @frame)
   end
 
   test "creates an Opus payloader and dispatches calls to its module" do
@@ -30,7 +29,7 @@ defmodule ExWebRTC.RTP.PayloaderTest do
              }
              |> Payloader.new()
 
-    assert Payloader.payload(payloader, @frame) == Opus.Payloader.payload(payloader, @frame)
+    assert Payloader.payload(payloader, @frame) == Payloader.Opus.payload(payloader, @frame)
   end
 
   test "returns error if no payloader exists for given codec" do

--- a/test/ex_webrtc/rtp/payloader_test.exs
+++ b/test/ex_webrtc/rtp/payloader_test.exs
@@ -14,7 +14,7 @@ defmodule ExWebRTC.RTP.PayloaderTest do
     # with options
     assert {:ok, payloader} =
              %RTPCodecParameters{payload_type: 96, mime_type: "video/VP8", clock_rate: 90_000}
-             |> Payloader.new(800)
+             |> Payloader.new(max_payload_size: 800)
 
     assert Payloader.payload(payloader, @frame) == Payloader.VP8.payload(payloader, @frame)
   end

--- a/test/ex_webrtc/rtp/vp8/depayloader_test.exs
+++ b/test/ex_webrtc/rtp/vp8/depayloader_test.exs
@@ -1,10 +1,11 @@
 defmodule ExWebRTC.RTP.VP8.DepayloaderTest do
   use ExUnit.Case, async: true
 
-  alias ExWebRTC.RTP.VP8.{Payload, Depayloader}
+  alias ExWebRTC.RTP.Depayloader
+  alias ExWebRTC.RTP.VP8.Payload
 
   test "write/2" do
-    depayloader = Depayloader.new()
+    depayloader = Depayloader.VP8.new()
     # random vp8 data, not necessarily correct
     data = <<0, 1, 2, 3>>
 
@@ -15,7 +16,7 @@ defmodule ExWebRTC.RTP.VP8.DepayloaderTest do
     packet = ExRTP.Packet.new(vp8_payload, marker: true)
 
     assert {^data, %{current_frame: nil, current_timestamp: nil} = depayloader} =
-             Depayloader.depayload(depayloader, packet)
+             Depayloader.VP8.depayload(depayloader, packet)
 
     # packet that doesn't start a new frame
     vp8_payload = %Payload{n: 0, s: 0, pid: 0, payload: data}
@@ -24,7 +25,7 @@ defmodule ExWebRTC.RTP.VP8.DepayloaderTest do
     packet = ExRTP.Packet.new(vp8_payload)
 
     assert {nil, %{current_frame: nil, current_timestamp: nil} = depayloader} =
-             Depayloader.depayload(depayloader, packet)
+             Depayloader.VP8.depayload(depayloader, packet)
 
     # packet that starts a new frame without finishing the previous one
     vp8_payload = %Payload{n: 0, s: 1, pid: 0, payload: data}
@@ -33,7 +34,7 @@ defmodule ExWebRTC.RTP.VP8.DepayloaderTest do
     packet = ExRTP.Packet.new(vp8_payload)
 
     assert {nil, %{current_frame: ^data, current_timestamp: 0} = depayloader} =
-             Depayloader.depayload(depayloader, packet)
+             Depayloader.VP8.depayload(depayloader, packet)
 
     data2 = data <> <<0>>
     vp8_payload = %Payload{n: 0, s: 1, pid: 0, payload: data2}
@@ -42,7 +43,7 @@ defmodule ExWebRTC.RTP.VP8.DepayloaderTest do
     packet = ExRTP.Packet.new(vp8_payload, timestamp: 3000)
 
     assert {nil, %{current_frame: ^data2, current_timestamp: 3000} = depayloader} =
-             Depayloader.depayload(depayloader, packet)
+             Depayloader.VP8.depayload(depayloader, packet)
 
     # packet with timestamp from a new frame that is not a beginning of this frame
     data2 = data
@@ -52,6 +53,6 @@ defmodule ExWebRTC.RTP.VP8.DepayloaderTest do
     packet = ExRTP.Packet.new(vp8_payload, timestamp: 6000)
 
     assert {nil, %{current_frame: nil, current_timestamp: nil}} =
-             Depayloader.depayload(depayloader, packet)
+             Depayloader.VP8.depayload(depayloader, packet)
   end
 end

--- a/test/ex_webrtc/rtp/vp8/payloader_test.exs
+++ b/test/ex_webrtc/rtp/vp8/payloader_test.exs
@@ -2,17 +2,17 @@ defmodule ExWebRTC.RTP.VP8.PayloaderTest do
   use ExUnit.Case, async: true
 
   alias ExWebRTC.Media.IVF.Reader
-  alias ExWebRTC.RTP.VP8.Payloader
+  alias ExWebRTC.RTP.Payloader
 
   test "payload vp8 video" do
     # video frames in the fixture are mostly 500+ bytes
-    vp8_payloader = Payloader.new(200)
+    vp8_payloader = Payloader.VP8.new(200)
     {:ok, _header, ivf_reader} = Reader.open("test/fixtures/ivf/vp8_correct.ivf")
 
     for _i <- 0..28, reduce: vp8_payloader do
       vp8_payloader ->
         {:ok, frame} = Reader.next_frame(ivf_reader)
-        {rtp_packets, vp8_payloader} = Payloader.payload(vp8_payloader, frame.data)
+        {rtp_packets, vp8_payloader} = Payloader.VP8.payload(vp8_payloader, frame.data)
 
         # assert all packets but last are 200 bytes
         rtp_packets


### PR DESCRIPTION
Sorry, I don't want to mess in your PR but I have a couple of observations:

* depayloaders does not take any options right now so we can get rid of them
* all payloaders can take the same argument - max_payload_size
* if the two above are true, we can hide everything except `ExWebRTC.RTP.Payloader` and `ExWebRTC.RTP.Depayloader` - user doesn't have to know about specific payloader/depayloader modules
* we can extract payloader/depayloader behaviours into separate modules so they are private too. If we want to provide automatic dispatching, user won't be able to implement those behaviours as our dispatcher's `new` function has to be modified anyway

An alternative approach would be to use Protocols. The API would look like this:

```elixir
defprotocol ExWebRTC.RTP.Payloader do
  def payload(t(), data) 
end

defprotocol ExWebRTC.RTP.Depayloader do
  def depayload(t(), data)
end

defmodule ExWebRTC.RTP.Utils do
  alias ExWebRTC.RTPCodecParameters
  
  @spec new_payloader(RTPCodecParameters.t()) :: ExWebRTC.RTP.Payloader.t()
  def new_payloader(codec_params) do
  end
  
  @spec new_depayloader(RTPCodecParameters.t()) :: ExWebRTC.RTP.Depayloader.t()
  def new_depayloader(codec_params) do
  end
end
```

This way, user can use RTP utils to automatically find payloader/depayloader or implement their own payloade/depayloader and still use our protocols.
This would be beneficial if we used those protocols internally, in PeerConnection but we don't right now.

Any thoughts?


