### PR TITLE
Fix rtcp for no track

### DIFF
--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -2087,6 +2087,9 @@ defmodule ExWebRTC.PeerConnection do
       nil ->
         {nil, state}
 
+      {%{sender: %{track: nil}}, _idx} ->
+        {nil, state}
+
       {tr, idx} ->
         tr = RTPTransceiver.receive_pli(tr, pli)
         transceivers = List.replace_at(state.transceivers, idx, tr)


### PR DESCRIPTION
It may happen, that after `removing_track`, we still receive PLI for that track, which has been already removed from the transceiver.

Below are logs from the fishjam media server

[pli-fail-logs.txt](https://github.com/user-attachments/files/17290362/pli-fail-logs.txt)
