### PR TITLE
Handle ICE candidates with missing `usernameFragment`

### DIFF
--- a/lib/ex_webrtc/ice_candidate.ex
+++ b/lib/ex_webrtc/ice_candidate.ex
@@ -23,6 +23,16 @@ defmodule ExWebRTC.ICECandidate do
   end
 
   @spec from_json(%{String.t() => String.t() | non_neg_integer() | nil}) :: t()
+  def from_json(
+        %{
+          "candidate" => c,
+          "sdpMid" => mid,
+          "sdpMLineIndex" => mline_idx
+        } = json
+      ) do
+    from_json(Map.put(json, "usernameFragment", nil))
+  end
+
   def from_json(%{
         "candidate" => c,
         "sdpMid" => mid,


### PR DESCRIPTION
I ran into an error because `flutter-webrtc`(https://github.com/flutter-webrtc/webrtc-interface/blob/767eb083a9ee88a4e37b49cb70bb7831c7c2414d/lib/src/rtc_ice_candidate.dart#L6) doesn't seem to send this field.

The ICECandidate type spec already allows the field to be nil. This PR would also allow candidates where the `usernameFragment` field is not present at all.