### PR TITLE
Don't forward user's RTP header extensions in `send_rtp/4`

### DIFF
--- a/lib/ex_webrtc/peer_connection/configuration.ex
+++ b/lib/ex_webrtc/peer_connection/configuration.ex
@@ -158,7 +158,12 @@ defmodule ExWebRTC.PeerConnection.Configuration do
           rtcp_feedbacks: [rtcp_feedback()]
         ]
 
-  @typedoc false
+  @typedoc """
+  `ExWebRTC.PeerConnection` configuration.
+
+  It is created from options passed to `ExWebRTC.PeerConnection.start_link/1`.
+  See `t:options/0` for more.
+  """
   @type t() :: %__MODULE__{
           controlling_process: Process.dest(),
           ice_servers: [ice_server()],


### PR DESCRIPTION
This PR ensures that we don't accidentally forward non-negotiated RTP header extensions in RTP packet.

When playing with simulcast, it is very common that `send_rtp/4` receives an RTP packet that contains extensions related to simulcast (e.g. RID). We should not forward them to the other side if they were not negotiated. 