### PR TITLE
Add ssrc attributes to the SDP

### DIFF
--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -870,7 +870,6 @@ defmodule ExWebRTC.PeerConnection do
   @impl true
   def handle_call({:add_track, %MediaStreamTrack{kind: kind} = track}, _from, state) do
     # we ignore the condition that sender has never been used to send
-    {ssrc, rtx_ssrc} = generate_ssrcs(state)
 
     {transceivers, sender} =
       state.transceivers
@@ -878,10 +877,12 @@ defmodule ExWebRTC.PeerConnection do
       |> Enum.find(fn {tr, _idx} -> RTPTransceiver.can_add_track?(tr, kind) end)
       |> case do
         {tr, idx} ->
-          tr = RTPTransceiver.add_track(tr, track, ssrc, rtx_ssrc)
+          tr = RTPTransceiver.add_track(tr, track)
           {List.replace_at(state.transceivers, idx, tr), tr.sender}
 
         nil ->
+          {ssrc, rtx_ssrc} = generate_ssrcs(state)
+
           options = [
             direction: :sendrecv,
             added_by_add_track: true,
@@ -910,8 +911,7 @@ defmodule ExWebRTC.PeerConnection do
         {:reply, {:error, :invalid_track_type}, state}
 
       {tr, idx} when tr.direction in [:sendrecv, :sendonly] ->
-        {ssrc, rtx_ssrc} = generate_ssrcs(state)
-        tr = RTPTransceiver.replace_track(tr, track, ssrc, rtx_ssrc)
+        tr = RTPTransceiver.replace_track(tr, track)
         transceivers = List.replace_at(state.transceivers, idx, tr)
         state = %{state | transceivers: transceivers}
         {:reply, :ok, state}
@@ -1649,7 +1649,13 @@ defmodule ExWebRTC.PeerConnection do
       transceivers =
         sdp.media
         |> Enum.reject(&SDPUtils.data_channel?/1)
-        |> process_mlines_remote(state.transceivers, type, state.config, state.owner)
+        |> process_mlines_remote(
+          state.transceivers,
+          type,
+          Map.keys(state.demuxer.ssrc_to_mid),
+          state.config,
+          state.owner
+        )
 
       # infer our role from the remote role
       dtls_role = if dtls_role in [:actpass, :passive], do: :active, else: :passive
@@ -1835,25 +1841,40 @@ defmodule ExWebRTC.PeerConnection do
   end
 
   # See W3C WebRTC 4.4.1.5-4.7.10.2
-  defp process_mlines_remote(mlines, transceivers, sdp_type, config, owner) do
+  defp process_mlines_remote(mlines, transceivers, sdp_type, demuxer_ssrcs, config, owner) do
     mlines_idx = Enum.with_index(mlines)
-    do_process_mlines_remote(mlines_idx, transceivers, sdp_type, config, owner)
+    do_process_mlines_remote(mlines_idx, transceivers, sdp_type, demuxer_ssrcs, config, owner)
   end
 
-  defp do_process_mlines_remote([], transceivers, _sdp_type, _config, _owner), do: transceivers
+  defp do_process_mlines_remote([], transceivers, _sdp_type, _demuxer_ssrcs, _config, _owner),
+    do: transceivers
 
-  defp do_process_mlines_remote([{mline, idx} | mlines], transceivers, sdp_type, config, owner) do
+  defp do_process_mlines_remote(
+         [{mline, idx} | mlines],
+         transceivers,
+         sdp_type,
+         demuxer_ssrcs,
+         config,
+         owner
+       ) do
     direction =
       if SDPUtils.rejected?(mline),
         do: :inactive,
         else: SDPUtils.get_media_direction(mline) |> reverse_direction()
+
+    rtp_sender_ssrcs = Enum.map(transceivers, & &1.sender.ssrc)
+    ssrcs = MapSet.new(demuxer_ssrcs ++ rtp_sender_ssrcs)
+
+    ssrc = do_generate_ssrc(ssrcs)
+    ssrcs = MapSet.put(ssrcs, ssrc)
+    rtx_ssrc = do_generate_ssrc(ssrcs)
 
     # Note: in theory we should update transceiver codecs
     # after processing remote track but this shouldn't have any impact
     {idx, tr} =
       case find_transceiver_from_remote(transceivers, mline) do
         {idx, tr} -> {idx, RTPTransceiver.update(tr, mline, config)}
-        nil -> {nil, RTPTransceiver.from_mline(mline, idx, config)}
+        nil -> {nil, RTPTransceiver.from_mline(mline, idx, ssrc, rtx_ssrc, config)}
       end
 
     tr = process_remote_track(tr, direction, owner)
@@ -1867,11 +1888,11 @@ defmodule ExWebRTC.PeerConnection do
     case idx do
       nil ->
         transceivers = transceivers ++ [tr]
-        do_process_mlines_remote(mlines, transceivers, sdp_type, config, owner)
+        do_process_mlines_remote(mlines, transceivers, sdp_type, demuxer_ssrcs, config, owner)
 
       idx ->
         transceivers = List.replace_at(transceivers, idx, tr)
-        do_process_mlines_remote(mlines, transceivers, sdp_type, config, owner)
+        do_process_mlines_remote(mlines, transceivers, sdp_type, demuxer_ssrcs, config, owner)
     end
   end
 
@@ -2186,6 +2207,8 @@ defmodule ExWebRTC.PeerConnection do
 
   # this is practically impossible so it's easier to raise
   # than to propagate the error up to the user
+  defp do_generate_ssrc(ssrcs, max_attempts \\ 200)
+
   defp do_generate_ssrc(_ssrcs, 0), do: raise("Couldn't find free SSRC")
 
   defp do_generate_ssrc(ssrcs, max_attempts) do

--- a/lib/ex_webrtc/rtp_sender.ex
+++ b/lib/ex_webrtc/rtp_sender.ex
@@ -21,7 +21,7 @@ defmodule ExWebRTC.RTPSender do
           mid: String.t() | nil,
           pt: non_neg_integer() | nil,
           rtx_pt: non_neg_integer() | nil,
-          # ssrc and rtx_ssrc are always present, even if there is no track
+          # ssrc and rtx_ssrc are always present, even if there is no track,
           # or transceiver direction is recvonly.
           # We preallocate them so they can be included in SDP when needed.
           ssrc: non_neg_integer(),
@@ -140,8 +140,8 @@ defmodule ExWebRTC.RTPSender do
     msid_attrs =
       case sender.track do
         nil ->
-          # In theory, we should do this "for each MediaStream that was associated with the transceiver"
-          # but web browsers (chrome, ff), include MSID even when there aren't any MediaStreams
+          # In theory, we should do this "for each MediaStream that was associated with the transceiver",
+          # but web browsers (chrome, ff) include MSID even when there aren't any MediaStreams
           [ExSDP.Attribute.MSID.new("-", nil)]
 
         %MediaStreamTrack{streams: streams} ->
@@ -192,13 +192,10 @@ defmodule ExWebRTC.RTPSender do
       streams ->
         {ssrc_attrs, rtx_ssrc_attrs} =
           Enum.reduce(streams, {[], []}, fn stream, {ssrc_attrs, rtx_ssrc_attrs} ->
-            ssrc_attr = [%ExSDP.Attribute.SSRC{id: ssrc, attribute: "msid", value: stream}]
+            ssrc_attr = %ExSDP.Attribute.SSRC{id: ssrc, attribute: "msid", value: stream}
             ssrc_attrs = [ssrc_attr | ssrc_attrs]
 
-            rtx_ssrc_attr = [
-              %ExSDP.Attribute.SSRC{id: rtx_ssrc, attribute: "msid", value: stream}
-            ]
-
+            rtx_ssrc_attr = %ExSDP.Attribute.SSRC{id: rtx_ssrc, attribute: "msid", value: stream}
             rtx_ssrc_attrs = [rtx_ssrc_attr | rtx_ssrc_attrs]
 
             {ssrc_attrs, rtx_ssrc_attrs}

--- a/lib/ex_webrtc/rtp_sender.ex
+++ b/lib/ex_webrtc/rtp_sender.ex
@@ -21,8 +21,11 @@ defmodule ExWebRTC.RTPSender do
           mid: String.t() | nil,
           pt: non_neg_integer() | nil,
           rtx_pt: non_neg_integer() | nil,
-          ssrc: non_neg_integer() | nil,
-          rtx_ssrc: non_neg_integer() | nil,
+          # ssrc and rtx_ssrc are always present, even if there is no track
+          # or transceiver direction is recvonly.
+          # We preallocate them so they can be included in SDP when needed.
+          ssrc: non_neg_integer(),
+          rtx_ssrc: non_neg_integer(),
           packets_sent: non_neg_integer(),
           bytes_sent: non_neg_integer(),
           retransmitted_packets_sent: non_neg_integer(),
@@ -68,8 +71,8 @@ defmodule ExWebRTC.RTPSender do
           RTPCodecParameters.t() | nil,
           [Extmap.t()],
           String.t() | nil,
-          non_neg_integer() | nil,
-          non_neg_integer() | nil,
+          non_neg_integer(),
+          non_neg_integer(),
           [atom()]
         ) :: sender()
   def new(track, codec, rtx_codec, rtp_hdr_exts, mid, ssrc, rtx_ssrc, features) do
@@ -129,6 +132,81 @@ defmodule ExWebRTC.RTPSender do
         rtx_pt: rtx_pt,
         report_recorder: report_recorder
     }
+  end
+
+  @spec get_mline_attrs(sender()) :: [ExSDP.Attribute.t()]
+  def get_mline_attrs(sender) do
+    # Don't include track id. See RFC 8829 sec. 5.2.1
+    msid_attrs =
+      case sender.track do
+        nil ->
+          # In theory, we should do this "for each MediaStream that was associated with the transceiver"
+          # but web browsers (chrome, ff), include MSID even when there aren't any MediaStreams
+          [ExSDP.Attribute.MSID.new("-", nil)]
+
+        %MediaStreamTrack{streams: streams} ->
+          case Enum.map(streams, &ExSDP.Attribute.MSID.new(&1, nil)) do
+            [] -> [ExSDP.Attribute.MSID.new("-", nil)]
+            other -> other
+          end
+      end
+
+    ssrc_attrs =
+      get_ssrc_attrs(sender.pt, sender.rtx_pt, sender.ssrc, sender.rtx_ssrc, sender.track)
+
+    msid_attrs ++ ssrc_attrs
+  end
+
+  # we didn't manage to negotiate any codec
+  defp get_ssrc_attrs(nil, _rtx_pt, _ssrc, _rtx_ssrc, _track) do
+    []
+  end
+
+  # we have a codec but not rtx
+  defp get_ssrc_attrs(_pt, nil, ssrc, _rtx_ssrc, track) do
+    streams = (track && track.streams) || []
+
+    case streams do
+      [] ->
+        [%ExSDP.Attribute.SSRC{id: ssrc, attribute: "msid", value: "-"}]
+
+      streams ->
+        Enum.map(streams, fn stream ->
+          %ExSDP.Attribute.SSRC{id: ssrc, attribute: "msid", value: stream}
+        end)
+    end
+  end
+
+  # we have both codec and rtx
+  defp get_ssrc_attrs(_pt, _rtx_pt, ssrc, rtx_ssrc, track) do
+    streams = (track && track.streams) || []
+
+    case streams do
+      [] ->
+        [
+          %ExSDP.Attribute.SSRCGroup{semantics: "FID", ssrcs: [ssrc, rtx_ssrc]},
+          %ExSDP.Attribute.SSRC{id: ssrc, attribute: "msid", value: "-"},
+          %ExSDP.Attribute.SSRC{id: rtx_ssrc, attribute: "msid", value: "-"}
+        ]
+
+      streams ->
+        {ssrc_attrs, rtx_ssrc_attrs} =
+          Enum.reduce(streams, {[], []}, fn stream, {ssrc_attrs, rtx_ssrc_attrs} ->
+            ssrc_attr = [%ExSDP.Attribute.SSRC{id: ssrc, attribute: "msid", value: stream}]
+            ssrc_attrs = [ssrc_attr | ssrc_attrs]
+
+            rtx_ssrc_attr = [
+              %ExSDP.Attribute.SSRC{id: rtx_ssrc, attribute: "msid", value: stream}
+            ]
+
+            rtx_ssrc_attrs = [rtx_ssrc_attr | rtx_ssrc_attrs]
+
+            {ssrc_attrs, rtx_ssrc_attrs}
+          end)
+
+        fid = %ExSDP.Attribute.SSRCGroup{semantics: "FID", ssrcs: [ssrc, rtx_ssrc]}
+        [fid | Enum.reverse(ssrc_attrs) ++ Enum.reverse(rtx_ssrc_attrs)]
+    end
   end
 
   @doc false

--- a/lib/ex_webrtc/rtp_sender/nack_responder.ex
+++ b/lib/ex_webrtc/rtp_sender/nack_responder.ex
@@ -28,8 +28,12 @@ defmodule ExWebRTC.RTPSender.NACKResponder do
 
     {packets, seq_no} =
       seq_nos
-      |> Enum.map(fn seq_no -> {seq_no, Map.get(responder.packets, rem(seq_no, @max_packets))} end)
-      |> Enum.filter(fn {seq_no, packet} -> packet != nil and packet.sequence_number == seq_no end)
+      |> Enum.map(fn seq_no ->
+        {seq_no, Map.get(responder.packets, rem(seq_no, @max_packets))}
+      end)
+      |> Enum.filter(fn {seq_no, packet} ->
+        packet != nil and packet.sequence_number == seq_no
+      end)
       # ssrc will be assigned by the sender
       |> Enum.map_reduce(responder.seq_no, fn {seq_no, packet}, rtx_seq_no ->
         rtx_packet = %Packet{

--- a/test/ex_webrtc/rtp_sender_test.exs
+++ b/test/ex_webrtc/rtp_sender_test.exs
@@ -2,7 +2,7 @@ defmodule ExWebRTC.RTPSenderTest do
   use ExUnit.Case, async: true
 
   alias ExRTP.Packet.Extension.SourceDescription
-  alias ExSDP.Attribute.{Extmap, FMTP}
+  alias ExSDP.Attribute.Extmap
 
   alias ExWebRTC.{MediaStreamTrack, RTPCodecParameters, RTPSender}
 

--- a/test/ex_webrtc/rtp_transceiver_test.exs
+++ b/test/ex_webrtc/rtp_transceiver_test.exs
@@ -1,0 +1,85 @@
+defmodule ExWebRTC.RTPTransceiverTest do
+  use ExUnit.Case, async: true
+
+  alias ExWebRTC.{MediaStreamTrack, PeerConnection, RTPTransceiver, Utils}
+
+  {:ok, pc} = PeerConnection.start_link()
+  @config PeerConnection.get_configuration(pc)
+  :ok = PeerConnection.close(pc)
+
+  @ssrc 1234
+  @rtx_ssrc 2345
+
+  @track MediaStreamTrack.new(:video, [MediaStreamTrack.generate_stream_id()])
+
+  {_key, cert} = ExDTLS.generate_key_cert()
+
+  @opts [
+    ice_ufrag: "ice_ufrag",
+    ice_pwd: "ice_pwd",
+    ice_options: "trickle",
+    fingerprint: {:sha256, Utils.hex_dump(cert)},
+    setup: :actpass
+  ]
+
+  describe "to_offer_mline/1" do
+    test "with sendrecv direction" do
+      tr = RTPTransceiver.new(:video, @track, @config, ssrc: @ssrc, rtx_ssrc: @rtx_ssrc)
+      test_sender_attrs_present(tr)
+    end
+
+    test "with sendonly direction" do
+      tr =
+        RTPTransceiver.new(:video, @track, @config,
+          ssrc: @ssrc,
+          rtx_ssrc: @rtx_ssrc,
+          direction: :sendonly
+        )
+
+      test_sender_attrs_present(tr)
+    end
+
+    test "with recvonly direction" do
+      tr =
+        RTPTransceiver.new(:video, @track, @config,
+          ssrc: @ssrc,
+          rtx_ssrc: @rtx_ssrc,
+          direction: :recvonly
+        )
+
+      test_sender_attrs_not_present(tr)
+    end
+
+    test "with inactive direction" do
+      tr =
+        RTPTransceiver.new(:video, @track, @config,
+          ssrc: @ssrc,
+          rtx_ssrc: @rtx_ssrc,
+          direction: :inactive
+        )
+
+      test_sender_attrs_not_present(tr)
+    end
+  end
+
+  defp test_sender_attrs_present(tr) do
+    mline = RTPTransceiver.to_offer_mline(tr, @opts)
+
+    # Assert rtp sender attributes are present.
+    # Their exact values are checked in rtp_sender_test.exs.
+    assert [%ExSDP.Attribute.MSID{}] = ExSDP.get_attributes(mline, ExSDP.Attribute.MSID)
+    assert [%ExSDP.Attribute.SSRCGroup{}] = ExSDP.get_attributes(mline, ExSDP.Attribute.SSRCGroup)
+
+    assert [%ExSDP.Attribute.SSRC{}, %ExSDP.Attribute.SSRC{}] =
+             ExSDP.get_attributes(mline, ExSDP.Attribute.SSRC)
+  end
+
+  defp test_sender_attrs_not_present(tr) do
+    mline = RTPTransceiver.to_offer_mline(tr, @opts)
+
+    # assert there are no sender attributes
+    assert [] == ExSDP.get_attributes(mline, ExSDP.Attribute.MSID)
+    assert [] == ExSDP.get_attributes(mline, ExSDP.Attribute.SSRCGroup)
+    assert [] == ExSDP.get_attributes(mline, ExSDP.Attribute.SSRC)
+  end
+end


### PR DESCRIPTION
Some implementations still rely on ssrc attributes in SDP offer/answer when demuxing incoming RTP packets (e.g. Pion). While including a=ssrc attribute in the SDP is obsoleted and we should demux by mid, including ssrc is still correct and supported by web browsers.

This PR adds ssrc attributes to the SDP offer/answer when a transceiver is sendonly or sendrecv.

A couple of notes:

* in theory, if we add `a=ssrc:1234` attribute, it should also always has cname attr i.e. `a=ssrc:1234 cname:qW34eced` (RFC 5567)
* we don't use cnames so we don't do this. Instead we always add msid attribute as we already have it
* we stop sending app_data in msid according to what JSEP says (RFC 8829). This app_data does not make any sense anyway as its value is MediaStreamTrack.id, which can change without renegotiation (e.g. when calling rtpsender.replaceTrack)
* we preallocate ssrc and rtx_ssrc even for recvonly transceivers. This is not fully correct, as ssrc should probably change after transceiver becomes inactive and active again but as far as I understand the code, we haven't been doing this so far anyway
* we don't add ssrc, ssrcgroup and msid attributes when transceiver is recvonly or inactive
* relevant rfcs: 
  * [RFC 8830](https://www.rfc-editor.org/rfc/rfc8830.html) - MediaStreams 
  * [RFC 8829](https://datatracker.ietf.org/doc/html/rfc8829) - JSEP 
  * [RFC 5576](https://datatracker.ietf.org/doc/html/rfc5576) - SSRC attribute and FID group