### PR TITLE
Pass all codecs instead of selected one to the rtp_receiver and rtp_sender

### DIFF
--- a/lib/ex_webrtc/rtp_receiver.ex
+++ b/lib/ex_webrtc/rtp_receiver.ex
@@ -61,9 +61,11 @@ defmodule ExWebRTC.RTPReceiver do
   end
 
   @doc false
-  @spec new(MediaStreamTrack.t(), RTPCodecParameters.t() | nil, [Extmap.t()], [atom()]) ::
-          receiver()
-  def new(track, codec, rtp_hdr_exts, features) do
+  @spec new(MediaStreamTrack.t(), [RTPCodecParameters.t()], [Extmap.t()], [atom()]) :: receiver()
+  def new(track, codecs, rtp_hdr_exts, features) do
+    {_rtx_codecs, media_codecs} = Utils.split_rtx_codecs(codecs)
+    codec = List.first(media_codecs)
+
     # layer `nil` is for the packets without RID/ no simulcast
     %{
       id: Utils.generate_id(),
@@ -77,8 +79,10 @@ defmodule ExWebRTC.RTPReceiver do
   end
 
   @doc false
-  @spec update(receiver(), RTPCodecParameters.t() | nil, [Extmap.t()], [String.t()]) :: receiver()
-  def update(receiver, codec, rtp_hdr_exts, stream_ids) do
+  @spec update(receiver(), [RTPCodecParameters.t()], [Extmap.t()], [String.t()]) :: receiver()
+  def update(receiver, codecs, rtp_hdr_exts, stream_ids) do
+    {_rtx_codecs, media_codecs} = Utils.split_rtx_codecs(codecs)
+    codec = List.first(media_codecs)
     simulcast_demuxer = SimulcastDemuxer.update(receiver.simulcast_demuxer, rtp_hdr_exts)
     track = %MediaStreamTrack{receiver.track | streams: stream_ids}
 

--- a/lib/ex_webrtc/utils.ex
+++ b/lib/ex_webrtc/utils.ex
@@ -1,5 +1,6 @@
 defmodule ExWebRTC.Utils do
   @moduledoc false
+  alias ExWebRTC.RTPCodecParameters
 
   @spec hex_dump(binary()) :: String.t()
   def hex_dump(binary) do
@@ -17,4 +18,10 @@ defmodule ExWebRTC.Utils do
   @spec to_int(boolean()) :: 0 | 1
   def to_int(false), do: 0
   def to_int(true), do: 1
+
+  @spec split_rtx_codecs([RTPCodecParameters.t()]) ::
+          {[RTPCodecParameters.t()], [RTPCodecParameters.t()]}
+  def split_rtx_codecs(codecs) do
+    Enum.split_with(codecs, &String.ends_with?(&1.mime_type, "/rtx"))
+  end
 end

--- a/test/ex_webrtc/rtp_receiver_test.exs
+++ b/test/ex_webrtc/rtp_receiver_test.exs
@@ -11,7 +11,7 @@ defmodule ExWebRTC.RTPReceiverTest do
     payload = <<1, 2, 3>>
 
     track = MediaStreamTrack.new(:audio)
-    receiver = RTPReceiver.new(track, @codec, [], [])
+    receiver = RTPReceiver.new(track, [@codec], [], [])
 
     assert [] == RTPReceiver.get_stats(receiver, timestamp)
 

--- a/test/ex_webrtc/rtp_sender_test.exs
+++ b/test/ex_webrtc/rtp_sender_test.exs
@@ -30,7 +30,7 @@ defmodule ExWebRTC.RTPSenderTest do
   setup do
     track = MediaStreamTrack.new(:video)
 
-    sender = RTPSender.new(track, @codec, nil, @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
+    sender = RTPSender.new(track, [@codec], @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
 
     %{sender: sender}
   end
@@ -66,7 +66,7 @@ defmodule ExWebRTC.RTPSenderTest do
       stream_id = MediaStreamTrack.generate_stream_id()
       track = MediaStreamTrack.new(:video, [stream_id])
 
-      sender = RTPSender.new(track, @codec, nil, @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
+      sender = RTPSender.new(track, [@codec], @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
 
       assert [
                %ExSDP.Attribute.MSID{id: ^stream_id, app_data: nil},
@@ -78,7 +78,8 @@ defmodule ExWebRTC.RTPSenderTest do
       stream_id = MediaStreamTrack.generate_stream_id()
       track = MediaStreamTrack.new(:video, [stream_id])
 
-      sender = RTPSender.new(track, @codec, @rtx_codec, @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
+      sender =
+        RTPSender.new(track, [@codec, @rtx_codec], @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
 
       assert [
                %ExSDP.Attribute.MSID{id: ^stream_id, app_data: nil},
@@ -91,7 +92,8 @@ defmodule ExWebRTC.RTPSenderTest do
     test "without media stream" do
       track = MediaStreamTrack.new(:video)
 
-      sender = RTPSender.new(track, @codec, @rtx_codec, @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
+      sender =
+        RTPSender.new(track, [@codec, @rtx_codec], @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
 
       assert [
                %ExSDP.Attribute.MSID{id: "-", app_data: nil},
@@ -107,7 +109,8 @@ defmodule ExWebRTC.RTPSenderTest do
 
       track = MediaStreamTrack.new(:video, [s1_id, s2_id])
 
-      sender = RTPSender.new(track, @codec, @rtx_codec, @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
+      sender =
+        RTPSender.new(track, [@codec, @rtx_codec], @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
 
       assert [
                %ExSDP.Attribute.MSID{id: ^s1_id, app_data: nil},


### PR DESCRIPTION
This PR passes all codecs that were negotiated to the RTP sender and RTP receiver. Because in our case these codecs are always the same i.e. (transceiver.codecs==sender.codecs==receiver.codecs), they are not publicly exposed in RTPSender and RTPReceiver structs to not create confusion or suggest that they may differ. 

The behavior of RTP sender and receiver remains the same i.e. they always pick the first codec and use it for sending or expect it when receiving RTP packets.

In the next PR, I am going to allow to set codec that should be used for sending. 