### PR TITLE
Add set_sender_codec

### DIFF
--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -194,6 +194,8 @@ defmodule ExWebRTC.PeerConnection do
 
   :ok = PeerConnection.set_sender_codec(pc, rtp_sender.id, h264 || vp8)
   ```
+
+  This function can only be called once the first negotiation passes.
   """
   @spec set_sender_codec(peer_connection(), RTPSender.id(), RTPCodecParameters.t()) ::
           :ok | {:error, term()}

--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -165,7 +165,7 @@ defmodule ExWebRTC.PeerConnection do
   should be used for sending.
 
   Once the first RTP packet is sent (via `send_rtp/4`), `set_sender_codec/3`
-  can only be called with a codec with the clock rate.
+  can only be called with a codec with the same clock rate.
 
   Although very unlikely, keep in mind that after renegotiation,
   the selected codec may no longer be supported by the remote side and you might
@@ -176,6 +176,10 @@ defmodule ExWebRTC.PeerConnection do
   ```
   {:ok, pc} = PeerConnection.start_link()
   {:ok, rtp_sender} = PeerConnection.add_track(MediaStreamTrack.new(:video))
+
+  # exchange SDP with the remote side
+  # {:ok, offer} = PeerConnection.create_offer(pc)
+  # ...
 
   tr =
     pc

--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -9,6 +9,7 @@ defmodule ExWebRTC.PeerConnection do
 
   require Logger
 
+  alias ExWebRTC.RTPCodecParameters
   alias __MODULE__.{Configuration, Demuxer, TWCCRecorder}
 
   alias ExWebRTC.{
@@ -153,7 +154,59 @@ defmodule ExWebRTC.PeerConnection do
   end
 
   @doc """
+  Sets the codec that will be used for sending RTP packets.
+
+  `send_rtp/4` overrides some of the RTP packet fields.
+  In particular, when multiple codecs are negotiated, `send_rtp/4` will use
+  payload type of the most preffered by the remote side codec (i.e. the first
+  one from the list of codecs in the remote description).
+
+  Use this function if you want to select, which codec (hence payload type)
+  should be used for sending.
+
+  Once the first RTP packet is sent (via `send_rtp/4`), `set_sender_codec/3`
+  can only be called with a codec with the clock rate.
+
+  Although very unlikely, keep in mind that after renegotiation,
+  the selected codec may no longer be supported by the remote side and you might
+  need to call this function again, passing a new codec.
+
+  To check available codecs you can use `get_transceivers/1`:
+
+  ```
+  {:ok, pc} = PeerConnection.start_link()
+  {:ok, rtp_sender} = PeerConnection.add_track(MediaStreamTrack.new(:video))
+
+  tr =
+    pc
+    |> PeerConnection.get_transceivers()
+    |> Enum.find(fn tr -> tr.sender.id == rtp_sender.id end)
+
+  dbg(tr.codecs) # list of supported codecs both for sending and receiving
+
+  # e.g. always prefer h264 over vp8
+  h264 = Enum.find(tr.codecs, fn codec -> codec.mime_type == "video/H264" end)
+  vp8 = Enum.find(tr.codecs, fn codec -> codec.mime_type == "video/VP8" end)
+
+  :ok = PeerConnection.set_sender_codec(pc, rtp_sender.id, h264 || vp8)
+  ```
+  """
+  @spec set_sender_codec(peer_connection(), RTPSender.id(), RTPCodecParameters.t()) ::
+          :ok | {:error, term()}
+  def set_sender_codec(peer_connection, sender_id, codec) do
+    GenServer.call(peer_connection, {:set_sender_codec, sender_id, codec})
+  end
+
+  @doc """
   Sends an RTP packet to the remote peer using the track specified by the `track_id`.
+
+  The following fields of the RTP packet will be overwritten by this function:
+  * payload type
+  * ssrc
+  * rtp header extensions
+
+  If you negotiated multiple codecs (hence payload types) and you want to choose,
+  which one should be used, see `set_sender_codec/3`.
 
   Options:
     * `rtx?` - send the packet as if it was retransmitted (use SSRC and payload type specific to RTX)
@@ -574,6 +627,31 @@ defmodule ExWebRTC.PeerConnection do
   @impl true
   def handle_call(:get_configuration, _from, state) do
     {:reply, state.config, state}
+  end
+
+  @impl true
+  def handle_call({:set_sender_codec, sender_id, codec}, _from, state) do
+    state.transceivers
+    |> Enum.with_index()
+    |> Enum.find(fn {tr, _idx} -> tr.sender.id == sender_id end)
+    |> case do
+      {tr, idx} when tr.direction in [:sendrecv, :sendonly] ->
+        case RTPTransceiver.set_sender_codec(tr, codec) do
+          {:ok, tr} ->
+            transceivers = List.replace_at(state.transceivers, idx, tr)
+            state = %{state | transceivers: transceivers}
+            {:reply, :ok, state}
+
+          {:error, _reason} = error ->
+            {:reply, error, state}
+        end
+
+      {_tr, _idx} ->
+        {:reply, {:error, :invalid_transceiver_direction}, state}
+
+      nil ->
+        {:reply, {:error, :invalid_sender_id}, state}
+    end
   end
 
   @impl true
@@ -1135,7 +1213,8 @@ defmodule ExWebRTC.PeerConnection do
           end
 
         {packet, tr} = RTPTransceiver.send_packet(tr, packet, rtx?)
-        :ok = DTLSTransport.send_rtp(state.dtls_transport, packet)
+
+        if packet != <<>>, do: :ok = DTLSTransport.send_rtp(state.dtls_transport, packet)
 
         transceivers = List.replace_at(state.transceivers, idx, tr)
         state = %{state | transceivers: transceivers}

--- a/lib/ex_webrtc/peer_connection/configuration.ex
+++ b/lib/ex_webrtc/peer_connection/configuration.ex
@@ -25,6 +25,11 @@ defmodule ExWebRTC.PeerConnection.Configuration do
 
   @default_video_codecs [
     %RTPCodecParameters{
+      payload_type: 96,
+      mime_type: "video/VP8",
+      clock_rate: 90_000
+    },
+    %RTPCodecParameters{
       payload_type: 98,
       mime_type: "video/H264",
       clock_rate: 90_000,
@@ -45,11 +50,6 @@ defmodule ExWebRTC.PeerConnection.Configuration do
         packetization_mode: 1,
         profile_level_id: 0x42E01F
       }
-    },
-    %RTPCodecParameters{
-      payload_type: 96,
-      mime_type: "video/VP8",
-      clock_rate: 90_000
     },
     %RTPCodecParameters{
       payload_type: 45,

--- a/lib/ex_webrtc/peer_connection/configuration.ex
+++ b/lib/ex_webrtc/peer_connection/configuration.ex
@@ -536,7 +536,7 @@ defmodule ExWebRTC.PeerConnection.Configuration do
           {nil, false} ->
             {rtx, free_pts}
 
-          # thre is no such codec, but its payload type is used
+          # there is no such codec, but its payload type is used
           {nil, true} ->
             [pt | rest] = free_pts
             rtx = do_update_codec(rtx, pt)
@@ -628,9 +628,7 @@ defmodule ExWebRTC.PeerConnection.Configuration do
       c1.channels == c2.channels and fmtp_equal?(c1, c2)
   end
 
-  @doc false
-  @spec codec_equal_soft?(RTPCodecParameters.t(), RTPCodecParameters.t()) :: boolean()
-  def codec_equal_soft?(c1, c2) do
+  defp codec_equal_soft?(c1, c2) do
     String.downcase(c1.mime_type) == String.downcase(c2.mime_type) and
       c1.clock_rate == c2.clock_rate and
       c1.channels == c2.channels and fmtp_equal_soft?(c1, c2)

--- a/lib/ex_webrtc/peer_connection/configuration.ex
+++ b/lib/ex_webrtc/peer_connection/configuration.ex
@@ -490,7 +490,7 @@ defmodule ExWebRTC.PeerConnection.Configuration do
   defp update_codecs(config, sdp) do
     %__MODULE__{audio_codecs: audio_codecs, video_codecs: video_codecs} = config
     sdp_codecs = SDPUtils.get_rtp_codec_parameters(sdp)
-    free_pts = get_free_payload_types(sdp_codecs)
+    free_pts = get_free_payload_types(audio_codecs ++ video_codecs ++ sdp_codecs)
 
     {audio_codecs, free_pts} = do_update_codecs(audio_codecs, sdp_codecs, free_pts)
     {video_codecs, _free_pts} = do_update_codecs(video_codecs, sdp_codecs, free_pts)

--- a/lib/ex_webrtc/peer_connection/configuration.ex
+++ b/lib/ex_webrtc/peer_connection/configuration.ex
@@ -433,6 +433,9 @@ defmodule ExWebRTC.PeerConnection.Configuration do
     config
     |> update_extensions(sdp)
     |> update_codecs(sdp)
+    # if update went wrong (there are duplicates in payload types),
+    # we should never continue as this may lead to hard to debug errors
+    |> ensure_unique_payload_types()
   end
 
   defp update_extensions(config, sdp) do

--- a/lib/ex_webrtc/rtp_sender.ex
+++ b/lib/ex_webrtc/rtp_sender.ex
@@ -263,8 +263,8 @@ defmodule ExWebRTC.RTPSender do
   defp rtx?(codec), do: String.ends_with?(codec.mime_type, "rtx")
   defp supported?(sender, codec), do: codec in sender.codecs
 
-  # As long as report recorder is not initialized i.e. we have not send any RTP packet
-  # allow for codec changes. Once we start sending RTP packet, require the same clock rate.
+  # As long as report recorder is not initialized i.e. we have not sent any RTP packet,
+  # allow for codec changes. Once we start sending RTP packets, require the same clock rate.
   defp same_clock_rate?(%{report_recorder: %{clock_rate: nil}}, _codec), do: true
   defp same_clock_rate?(sender, codec), do: sender.report_recorder.clock_rate == codec.clock_rate
 

--- a/lib/ex_webrtc/rtp_sender.ex
+++ b/lib/ex_webrtc/rtp_sender.ex
@@ -146,9 +146,9 @@ defmodule ExWebRTC.RTPSender do
   defp log_rtx_codec_change(%{rtx_codec: rtx_codec} = sender, nil, neg_codecs)
        when rtx_codec != nil do
     Logger.warning("""
-    Unselecting RTP sender codec as it is no longer supported by the remote side.
+    Unselecting RTP sender RTX codec as it is no longer supported by the remote side.
     Call set_sender_codec again passing supported codec.
-    Codec: #{inspect(sender.codec)}
+    Codec: #{inspect(sender.rtx_codec)}
     Currently negotiated codecs: #{inspect(neg_codecs)}
     """)
   end

--- a/lib/ex_webrtc/rtp_sender/report_recorder.ex
+++ b/lib/ex_webrtc/rtp_sender/report_recorder.ex
@@ -29,6 +29,14 @@ defmodule ExWebRTC.RTPSender.ReportRecorder do
             packet_count: 0,
             octet_count: 0
 
+  @spec init(t(), non_neg_integer(), non_neg_integer()) :: t()
+  def init(%{clock_rate: nil, sender_ssrc: nil}, clock_rate, sender_ssrc) do
+    %__MODULE__{clock_rate: clock_rate, sender_ssrc: sender_ssrc}
+  end
+
+  def init(_recorder, _clock_rate, _sender_ssrc),
+    do: raise("Tried to re-initialize ReportRecorder")
+
   @doc """
   Records incoming RTP packet.
 

--- a/lib/ex_webrtc/rtp_sender/report_recorder.ex
+++ b/lib/ex_webrtc/rtp_sender/report_recorder.ex
@@ -50,8 +50,7 @@ defmodule ExWebRTC.RTPSender.ReportRecorder do
   def record_packet(%{last_seq_no: nil} = recorder, packet, time) do
     %__MODULE__{
       recorder
-      | sender_ssrc: packet.ssrc,
-        last_rtp_timestamp: packet.timestamp,
+      | last_rtp_timestamp: packet.timestamp,
         last_seq_no: packet.sequence_number,
         last_timestamp: time,
         packet_count: 1,

--- a/lib/ex_webrtc/rtp_transceiver.ex
+++ b/lib/ex_webrtc/rtp_transceiver.ex
@@ -137,16 +137,7 @@ defmodule ExWebRTC.RTPTransceiver do
 
     receiver = RTPReceiver.new(track, codecs, header_extensions, config.features)
 
-    sender =
-      RTPSender.new(
-        sender_track,
-        codecs,
-        header_extensions,
-        nil,
-        options[:ssrc],
-        options[:rtx_ssrc],
-        config.features
-      )
+    sender = RTPSender.new(sender_track, options[:ssrc], options[:rtx_ssrc], config.features)
 
     %{
       id: id,
@@ -202,16 +193,8 @@ defmodule ExWebRTC.RTPTransceiver do
 
     receiver = RTPReceiver.new(track, codecs, header_extensions, config.features)
 
-    sender =
-      RTPSender.new(
-        nil,
-        codecs,
-        header_extensions,
-        mid,
-        ssrc,
-        rtx_ssrc,
-        config.features
-      )
+    sender = RTPSender.new(nil, ssrc, rtx_ssrc, config.features)
+    sender = RTPSender.update(sender, mid, codecs, header_extensions)
 
     %{
       id: id,
@@ -561,7 +544,19 @@ defmodule ExWebRTC.RTPTransceiver do
     # add sender attrs only if we send
     sender_attrs =
       if direction in [:sendonly, :sendrecv] do
-        RTPSender.get_mline_attrs(transceiver.sender)
+        # sender codecs are set when negotiation completes,
+        # hence, to generate the first offer, we need to use transceiver codecs
+        codecs =
+          if transceiver.sender.codecs == [],
+            do: transceiver.codecs,
+            else: transceiver.sender.codecs
+
+        get_sender_attrs(
+          transceiver.sender.track,
+          codecs,
+          transceiver.sender.ssrc,
+          transceiver.sender.rtx_ssrc
+        )
       else
         []
       end
@@ -573,6 +568,89 @@ defmodule ExWebRTC.RTPTransceiver do
         connection_data: [%ExSDP.ConnectionData{address: {0, 0, 0, 0}}]
     }
     |> ExSDP.add_attributes(attributes ++ media_formats ++ sender_attrs)
+  end
+
+  @doc false
+  defp get_sender_attrs(track, codecs, ssrc, rtx_ssrc) do
+    # Don't include track id. See RFC 8829 sec. 5.2.1
+    msid_attrs =
+      case track do
+        %MediaStreamTrack{streams: streams} when streams != [] ->
+          Enum.map(streams, &ExSDP.Attribute.MSID.new(&1, nil))
+
+        _other ->
+          # In theory, we should do this "for each MediaStream that was associated with the transceiver",
+          # but web browsers (chrome, ff) include MSID even when there aren't any MediaStreams
+          [ExSDP.Attribute.MSID.new("-", nil)]
+      end
+
+    ssrc_attrs = get_ssrc_attrs(codecs, ssrc, rtx_ssrc, track)
+
+    msid_attrs ++ ssrc_attrs
+  end
+
+  defp get_ssrc_attrs(codecs, ssrc, rtx_ssrc, track) do
+    codec = Enum.any?(codecs, fn codec -> not String.ends_with?(codec.mime_type, "/rtx") end)
+    rtx_codec = Enum.any?(codecs, fn codec -> String.ends_with?(codec.mime_type, "/rtx") end)
+
+    do_get_ssrc_attrs(codec, rtx_codec, ssrc, rtx_ssrc, track)
+  end
+
+  # we didn't manage to negotiate any codec
+  defp do_get_ssrc_attrs(false, _rtx_codec, _ssrc, _rtx_ssrc, _track) do
+    []
+  end
+
+  # we have a codec but not rtx codec
+  defp do_get_ssrc_attrs(_codec, false, ssrc, _rtx_ssrc, track) do
+    streams = (track && track.streams) || []
+
+    case streams do
+      [] ->
+        [%ExSDP.Attribute.SSRC{id: ssrc, attribute: "msid", value: "-"}]
+
+      streams ->
+        Enum.map(streams, fn stream ->
+          %ExSDP.Attribute.SSRC{id: ssrc, attribute: "msid", value: stream}
+        end)
+    end
+  end
+
+  # we have both codec and rtx codec
+  defp do_get_ssrc_attrs(_codec, _rtx_codec, ssrc, rtx_ssrc, track) do
+    streams = (track && track.streams) || []
+
+    fid = %ExSDP.Attribute.SSRCGroup{semantics: "FID", ssrcs: [ssrc, rtx_ssrc]}
+
+    ssrc_attrs =
+      case streams do
+        [] ->
+          [
+            %ExSDP.Attribute.SSRC{id: ssrc, attribute: "msid", value: "-"},
+            %ExSDP.Attribute.SSRC{id: rtx_ssrc, attribute: "msid", value: "-"}
+          ]
+
+        streams ->
+          {ssrc_attrs, rtx_ssrc_attrs} =
+            Enum.reduce(streams, {[], []}, fn stream, {ssrc_attrs, rtx_ssrc_attrs} ->
+              ssrc_attr = %ExSDP.Attribute.SSRC{id: ssrc, attribute: "msid", value: stream}
+              ssrc_attrs = [ssrc_attr | ssrc_attrs]
+
+              rtx_ssrc_attr = %ExSDP.Attribute.SSRC{
+                id: rtx_ssrc,
+                attribute: "msid",
+                value: stream
+              }
+
+              rtx_ssrc_attrs = [rtx_ssrc_attr | rtx_ssrc_attrs]
+
+              {ssrc_attrs, rtx_ssrc_attrs}
+            end)
+
+          Enum.reverse(ssrc_attrs) ++ Enum.reverse(rtx_ssrc_attrs)
+      end
+
+    [fid | ssrc_attrs]
   end
 
   # RFC 3264 (6.1) + RFC 8829 (5.3.1)

--- a/test/ex_webrtc/peer_connection_test.exs
+++ b/test/ex_webrtc/peer_connection_test.exs
@@ -220,20 +220,30 @@ defmodule ExWebRTC.PeerConnectionTest do
   end
 
   test "set_sender_codec/3" do
-    {:ok, pid} = PeerConnection.start_link()
-    {:ok, tr} = PeerConnection.add_transceiver(pid, :video)
+    {:ok, pc1} = PeerConnection.start_link()
+    {:ok, pc2} = PeerConnection.start_link()
+    {:ok, tr} = PeerConnection.add_transceiver(pc1, :video)
 
     {_rtx_codecs, media_codecs} = Utils.split_rtx_codecs(tr.codecs)
 
-    assert :ok = PeerConnection.set_sender_codec(pid, tr.sender.id, List.last(media_codecs))
-
     assert {:error, :invalid_sender_id} =
-             PeerConnection.set_sender_codec(pid, "invalid_id", List.last(media_codecs))
+             PeerConnection.set_sender_codec(pc1, "invalid_id", List.last(media_codecs))
 
-    :ok = PeerConnection.set_transceiver_direction(pid, tr.id, :recvonly)
+    :ok = PeerConnection.set_transceiver_direction(pc1, tr.id, :recvonly)
 
     assert {:error, :invalid_transceiver_direction} =
-             PeerConnection.set_sender_codec(pid, tr.sender.id, List.last(media_codecs))
+             PeerConnection.set_sender_codec(pc1, tr.sender.id, List.last(media_codecs))
+
+    # reset transceiver direction
+    :ok = PeerConnection.set_transceiver_direction(pc1, tr.id, :sendrecv)
+
+    # setting codec before negotiation should fail
+    assert {:error, :invalid_codec} =
+             PeerConnection.set_sender_codec(pc1, tr.sender.id, List.last(media_codecs))
+
+    :ok = negotiate(pc1, pc2)
+
+    assert :ok = PeerConnection.set_sender_codec(pc1, tr.sender.id, List.last(media_codecs))
   end
 
   test "send_rtp/4" do

--- a/test/ex_webrtc/peer_connection_test.exs
+++ b/test/ex_webrtc/peer_connection_test.exs
@@ -219,6 +219,23 @@ defmodule ExWebRTC.PeerConnectionTest do
     assert_receive {:ex_webrtc, _pid, {:connection_state_change, :new}}
   end
 
+  test "set_sender_codec/3" do
+    {:ok, pid} = PeerConnection.start_link()
+    {:ok, tr} = PeerConnection.add_transceiver(pid, :video)
+
+    {rtx_codecs, media_codecs} = Utils.split_rtx_codecs(tr.codecs)
+
+    assert :ok = PeerConnection.set_sender_codec(pid, tr.sender.id, List.last(media_codecs))
+
+    assert {:error, :invalid_sender_id} =
+             PeerConnection.set_sender_codec(pid, "invalid_id", List.last(media_codecs))
+
+    :ok = PeerConnection.set_transceiver_direction(pid, tr.id, :recvonly)
+
+    assert {:error, :invalid_transceiver_direction} =
+             PeerConnection.set_sender_codec(pid, tr.sender.id, List.last(media_codecs))
+  end
+
   test "send_rtp/4" do
     {:ok, pc1} = PeerConnection.start_link()
     {:ok, pc2} = PeerConnection.start_link()

--- a/test/ex_webrtc/peer_connection_test.exs
+++ b/test/ex_webrtc/peer_connection_test.exs
@@ -223,7 +223,7 @@ defmodule ExWebRTC.PeerConnectionTest do
     {:ok, pid} = PeerConnection.start_link()
     {:ok, tr} = PeerConnection.add_transceiver(pid, :video)
 
-    {rtx_codecs, media_codecs} = Utils.split_rtx_codecs(tr.codecs)
+    {_rtx_codecs, media_codecs} = Utils.split_rtx_codecs(tr.codecs)
 
     assert :ok = PeerConnection.set_sender_codec(pid, tr.sender.id, List.last(media_codecs))
 

--- a/test/ex_webrtc/renegotiation_test.exs
+++ b/test/ex_webrtc/renegotiation_test.exs
@@ -155,7 +155,7 @@ defmodule ExWebRTC.RenegotiationTest do
   test "add and remove tracks in a loop" do
     # Simulate the most basic videoconference scenario
     # where both sides join with audio and video,
-    # start screensharing and remove screensharing. 
+    # start screensharing and remove screensharing.
     # pc1 adds audio and video tracks
     # pc2 adds audio and video tracks
     # pc1 adds screenshare track

--- a/test/ex_webrtc/rtp_sender/report_recorder_test.exs
+++ b/test/ex_webrtc/rtp_sender/report_recorder_test.exs
@@ -15,6 +15,15 @@ defmodule ExWebRTC.RTPSender.ReportRecorderTest do
   @ntp_offset 2_208_988_800
   @max_u32 0xFFFFFFFF
 
+  test "init/3" do
+    recorder = %ReportRecorder{}
+
+    %{clock_rate: 90_000, sender_ssrc: 1234} =
+      recorder = ReportRecorder.init(recorder, 90_000, 1234)
+
+    assert_raise RuntimeError, fn -> ReportRecorder.init(recorder, 90_000, 1234) end
+  end
+
   describe "record_packet/3" do
     test "keeps track of packet counts and sizes" do
       recorder =
@@ -78,7 +87,7 @@ defmodule ExWebRTC.RTPSender.ReportRecorderTest do
 
       native_in_sec = System.convert_time_unit(1, :second, :native)
       seconds = 89_934
-      # 1/8, so 0.001 in binary 
+      # 1/8, so 0.001 in binary
       frac = 0.125
 
       assert {:ok, report, _recorder} =

--- a/test/ex_webrtc/rtp_sender/report_recorder_test.exs
+++ b/test/ex_webrtc/rtp_sender/report_recorder_test.exs
@@ -10,7 +10,7 @@ defmodule ExWebRTC.RTPSender.ReportRecorderTest do
   @rtp_ts 234_444
   @clock_rate 90_000
   @packet ExRTP.Packet.new(<<>>, sequence_number: @seq_no, timestamp: @rtp_ts)
-  @recorder %ReportRecorder{sender_ssrc: 123_467, clock_rate: @clock_rate}
+  @recorder ReportRecorder.init(%ReportRecorder{}, 123_467, @clock_rate)
 
   @ntp_offset 2_208_988_800
   @max_u32 0xFFFFFFFF

--- a/test/ex_webrtc/rtp_sender/report_recorder_test.exs
+++ b/test/ex_webrtc/rtp_sender/report_recorder_test.exs
@@ -10,7 +10,7 @@ defmodule ExWebRTC.RTPSender.ReportRecorderTest do
   @rtp_ts 234_444
   @clock_rate 90_000
   @packet ExRTP.Packet.new(<<>>, sequence_number: @seq_no, timestamp: @rtp_ts)
-  @recorder ReportRecorder.init(%ReportRecorder{}, 123_467, @clock_rate)
+  @recorder ReportRecorder.init(%ReportRecorder{}, @clock_rate, 123_467)
 
   @ntp_offset 2_208_988_800
   @max_u32 0xFFFFFFFF

--- a/test/ex_webrtc/rtp_sender_test.exs
+++ b/test/ex_webrtc/rtp_sender_test.exs
@@ -49,7 +49,7 @@ defmodule ExWebRTC.RTPSenderTest do
     %{sender: sender}
   end
 
-  test "new/6" do
+  test "new/7" do
     track = MediaStreamTrack.new(:video)
 
     codecs = [@vp8, @av1, @av1_45khz, @rtx]

--- a/test/ex_webrtc/rtp_sender_test.exs
+++ b/test/ex_webrtc/rtp_sender_test.exs
@@ -25,10 +25,10 @@ defmodule ExWebRTC.RTPSenderTest do
   }
 
   @av1_45khz %RTPCodecParameters{
-    payload_type: 45,
+    payload_type: 46,
     mime_type: "video/AV1",
     clock_rate: 45_000,
-    sdp_fmtp_line: %ExSDP.Attribute.FMTP{pt: 45, level_idx: 5, profile: 0, tier: 0}
+    sdp_fmtp_line: %ExSDP.Attribute.FMTP{pt: 46, level_idx: 5, profile: 0, tier: 0}
   }
 
   @rtx %ExWebRTC.RTPCodecParameters{
@@ -41,29 +41,30 @@ defmodule ExWebRTC.RTPSenderTest do
     }
   }
 
-  setup do
-    track = MediaStreamTrack.new(:video)
-
-    sender = RTPSender.new(track, [@vp8, @av1, @rtx], @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
-
-    %{sender: sender}
-  end
-
   test "new/7" do
     track = MediaStreamTrack.new(:video)
 
-    codecs = [@vp8, @av1, @av1_45khz, @rtx]
-    sender = RTPSender.new(track, codecs, @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
+    sender = RTPSender.new(track, @ssrc, @rtx_ssrc, [])
 
-    assert sender.codec == @vp8
-    assert sender.rtx_codec == @rtx
+    assert sender.track == track
+    assert sender.codec == nil
+    assert sender.rtx_codec == nil
+    assert sender.codecs == []
+    assert sender.rtp_hdr_exts == %{}
   end
 
-  test "set_codec/2" do
-    track = MediaStreamTrack.new(:video)
+  test "set_codecs/2" do
+    sender = RTPSender.new(nil, @ssrc, @rtx_ssrc, [])
 
-    codecs = [@vp8, @av1, @av1_45khz, @rtx]
-    sender = RTPSender.new(track, codecs, @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
+    # Before codecs are negotaited (i.e. update is called),
+    # sender's state should be clean, and setting codecs shouldn't be possible.
+    assert sender.codec == nil
+    assert sender.rtx_codec == nil
+    assert sender.codecs == []
+    assert sender.rtp_hdr_exts == %{}
+    assert {:error, :invalid_codec} = RTPSender.set_codec(sender, @av1)
+
+    sender = RTPSender.update(sender, "1", [@vp8, @av1, @av1_45khz, @rtx], @rtp_hdr_exts)
     assert sender.codec == @vp8
 
     assert {:ok, %{codec: @av1} = sender} = RTPSender.set_codec(sender, @av1)
@@ -71,6 +72,7 @@ defmodule ExWebRTC.RTPSenderTest do
     assert {:error, :invalid_codec} =
              RTPSender.set_codec(sender, %{@av1 | payload_type: @av1.payload_type + 1})
 
+    # rtx codec shouldn't be accepted
     assert {:error, :invalid_codec} = RTPSender.set_codec(sender, @rtx)
 
     # codec with different clock rate should be accepted
@@ -83,18 +85,30 @@ defmodule ExWebRTC.RTPSenderTest do
 
   test "update/4" do
     track = MediaStreamTrack.new(:video)
-    sender = RTPSender.new(track, [@vp8, @av1, @rtx], @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
+    sender = RTPSender.new(track, @ssrc, @rtx_ssrc, [])
 
-    assert %{codec: @vp8, rtx_codec: @rtx} =
+    assert %{codec: @vp8, rtx_codec: @rtx, codecs: [@vp8, @av1, @rtx]} =
+             sender =
              RTPSender.update(sender, "1", [@vp8, @av1, @rtx], @rtp_hdr_exts)
 
     assert %{codec: @vp8, rtx_codec: nil} =
+             sender =
              RTPSender.update(sender, "1", [@vp8, @av1], @rtp_hdr_exts)
 
+    assert %{codec: nil, rtx_codec: nil} =
+             sender = RTPSender.update(sender, "1", [@av1], @rtp_hdr_exts)
+
+    # once codec is cleared, another update shouldn't set it (until set_codec clears selected codec)
     assert %{codec: nil, rtx_codec: nil} = RTPSender.update(sender, "1", [@av1], @rtp_hdr_exts)
   end
 
   describe "send_packet/3" do
+    setup do
+      track = MediaStreamTrack.new(:video)
+      sender = RTPSender.new(track, @ssrc, @rtx_ssrc, [])
+      %{sender: sender}
+    end
+
     test "when there is no codec", %{sender: sender} do
       sender = RTPSender.update(sender, "1", [], @rtp_hdr_exts)
       assert {<<>>, ^sender} = RTPSender.send_packet(sender, ExRTP.Packet.new(<<>>), false)
@@ -106,6 +120,8 @@ defmodule ExWebRTC.RTPSenderTest do
     end
 
     test "when there is codec", %{sender: sender} do
+      sender = RTPSender.update(sender, "1", [@vp8], @rtp_hdr_exts)
+
       packet = ExRTP.Packet.new(<<>>)
 
       {packet, sender} = RTPSender.send_packet(sender, packet, false)
@@ -136,67 +152,10 @@ defmodule ExWebRTC.RTPSenderTest do
     end
   end
 
-  describe "get_mline_attrs/1" do
-    test "without rtx" do
-      stream_id = MediaStreamTrack.generate_stream_id()
-      track = MediaStreamTrack.new(:video, [stream_id])
+  test "get_stats/2" do
+    track = MediaStreamTrack.new(:video)
+    sender = RTPSender.new(track, @ssrc, @rtx_ssrc, [])
 
-      sender = RTPSender.new(track, [@vp8], @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
-
-      assert [
-               %ExSDP.Attribute.MSID{id: ^stream_id, app_data: nil},
-               %ExSDP.Attribute.SSRC{id: @ssrc, attribute: "msid", value: ^stream_id}
-             ] = RTPSender.get_mline_attrs(sender)
-    end
-
-    test "with rtx" do
-      stream_id = MediaStreamTrack.generate_stream_id()
-      track = MediaStreamTrack.new(:video, [stream_id])
-
-      sender = RTPSender.new(track, [@vp8, @rtx], @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
-
-      assert [
-               %ExSDP.Attribute.MSID{id: ^stream_id, app_data: nil},
-               %ExSDP.Attribute.SSRCGroup{semantics: "FID", ssrcs: [@ssrc, @rtx_ssrc]},
-               %ExSDP.Attribute.SSRC{id: @ssrc, attribute: "msid", value: ^stream_id},
-               %ExSDP.Attribute.SSRC{id: @rtx_ssrc, attribute: "msid", value: ^stream_id}
-             ] = RTPSender.get_mline_attrs(sender)
-    end
-
-    test "without media stream" do
-      track = MediaStreamTrack.new(:video)
-
-      sender = RTPSender.new(track, [@vp8, @rtx], @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
-
-      assert [
-               %ExSDP.Attribute.MSID{id: "-", app_data: nil},
-               %ExSDP.Attribute.SSRCGroup{semantics: "FID", ssrcs: [@ssrc, @rtx_ssrc]},
-               %ExSDP.Attribute.SSRC{id: @ssrc, attribute: "msid", value: "-"},
-               %ExSDP.Attribute.SSRC{id: @rtx_ssrc, attribute: "msid", value: "-"}
-             ] = RTPSender.get_mline_attrs(sender)
-    end
-
-    test "with multiple media streams" do
-      s1_id = MediaStreamTrack.generate_stream_id()
-      s2_id = MediaStreamTrack.generate_stream_id()
-
-      track = MediaStreamTrack.new(:video, [s1_id, s2_id])
-
-      sender = RTPSender.new(track, [@vp8, @rtx], @rtp_hdr_exts, "1", @ssrc, @rtx_ssrc, [])
-
-      assert [
-               %ExSDP.Attribute.MSID{id: ^s1_id, app_data: nil},
-               %ExSDP.Attribute.MSID{id: ^s2_id, app_data: nil},
-               %ExSDP.Attribute.SSRCGroup{semantics: "FID", ssrcs: [@ssrc, @rtx_ssrc]},
-               %ExSDP.Attribute.SSRC{id: @ssrc, attribute: "msid", value: ^s1_id},
-               %ExSDP.Attribute.SSRC{id: @ssrc, attribute: "msid", value: ^s2_id},
-               %ExSDP.Attribute.SSRC{id: @rtx_ssrc, attribute: "msid", value: ^s1_id},
-               %ExSDP.Attribute.SSRC{id: @rtx_ssrc, attribute: "msid", value: ^s2_id}
-             ] = RTPSender.get_mline_attrs(sender)
-    end
-  end
-
-  test "get_stats/2", %{sender: sender} do
     timestamp = System.os_time(:millisecond)
     payload = <<1, 2, 3>>
 
@@ -214,6 +173,8 @@ defmodule ExWebRTC.RTPSenderTest do
              retransmitted_packets_sent: 0,
              retransmitted_bytes_sent: 0
            } == RTPSender.get_stats(sender, timestamp)
+
+    sender = RTPSender.update(sender, "1", [@vp8, @rtx], @rtp_hdr_exts)
 
     packet = ExRTP.Packet.new(payload)
     {data1, sender} = RTPSender.send_packet(sender, packet, false)

--- a/test/ex_webrtc/rtp_transceiver_test.exs
+++ b/test/ex_webrtc/rtp_transceiver_test.exs
@@ -94,13 +94,11 @@ defmodule ExWebRTC.RTPTransceiverTest do
 
       mline = RTPTransceiver.to_offer_mline(tr, @opts)
 
-      assert [
-               %ExSDP.Attribute.MSID{id: @stream_id, app_data: nil}
-             ] = ExSDP.get_attributes(mline, ExSDP.Attribute.MSID)
+      assert [%ExSDP.Attribute.MSID{id: @stream_id, app_data: nil}] =
+               ExSDP.get_attributes(mline, ExSDP.Attribute.MSID)
 
-      assert [
-               %ExSDP.Attribute.SSRCGroup{semantics: "FID", ssrcs: [@ssrc, @rtx_ssrc]}
-             ] = ExSDP.get_attributes(mline, ExSDP.Attribute.SSRCGroup)
+      assert [%ExSDP.Attribute.SSRCGroup{semantics: "FID", ssrcs: [@ssrc, @rtx_ssrc]}] =
+               ExSDP.get_attributes(mline, ExSDP.Attribute.SSRCGroup)
 
       assert [
                %ExSDP.Attribute.SSRC{id: @ssrc, attribute: "msid", value: @stream_id},
@@ -120,13 +118,11 @@ defmodule ExWebRTC.RTPTransceiverTest do
 
       mline = RTPTransceiver.to_offer_mline(tr, @opts)
 
-      assert [
-               %ExSDP.Attribute.MSID{id: "-", app_data: nil}
-             ] = ExSDP.get_attributes(mline, ExSDP.Attribute.MSID)
+      assert [%ExSDP.Attribute.MSID{id: "-", app_data: nil}] =
+               ExSDP.get_attributes(mline, ExSDP.Attribute.MSID)
 
-      assert [
-               %ExSDP.Attribute.SSRCGroup{semantics: "FID", ssrcs: [@ssrc, @rtx_ssrc]}
-             ] = ExSDP.get_attributes(mline, ExSDP.Attribute.SSRCGroup)
+      assert [%ExSDP.Attribute.SSRCGroup{semantics: "FID", ssrcs: [@ssrc, @rtx_ssrc]}] =
+               ExSDP.get_attributes(mline, ExSDP.Attribute.SSRCGroup)
 
       assert [
                %ExSDP.Attribute.SSRC{id: @ssrc, attribute: "msid", value: "-"},
@@ -154,9 +150,8 @@ defmodule ExWebRTC.RTPTransceiverTest do
                %ExSDP.Attribute.MSID{id: ^s2_id, app_data: nil}
              ] = ExSDP.get_attributes(mline, ExSDP.Attribute.MSID)
 
-      assert [
-               %ExSDP.Attribute.SSRCGroup{semantics: "FID", ssrcs: [@ssrc, @rtx_ssrc]}
-             ] = ExSDP.get_attributes(mline, ExSDP.Attribute.SSRCGroup)
+      assert [%ExSDP.Attribute.SSRCGroup{semantics: "FID", ssrcs: [@ssrc, @rtx_ssrc]}] =
+               ExSDP.get_attributes(mline, ExSDP.Attribute.SSRCGroup)
 
       assert [
                %ExSDP.Attribute.SSRC{id: @ssrc, attribute: "msid", value: ^s1_id},

--- a/test/ex_webrtc/rtp_transceiver_test.exs
+++ b/test/ex_webrtc/rtp_transceiver_test.exs
@@ -10,7 +10,8 @@ defmodule ExWebRTC.RTPTransceiverTest do
   @ssrc 1234
   @rtx_ssrc 2345
 
-  @track MediaStreamTrack.new(:video, [MediaStreamTrack.generate_stream_id()])
+  @stream_id MediaStreamTrack.generate_stream_id()
+  @track MediaStreamTrack.new(:video, [@stream_id])
 
   {_key, cert} = ExDTLS.generate_key_cert()
 
@@ -60,13 +61,136 @@ defmodule ExWebRTC.RTPTransceiverTest do
 
       test_sender_attrs_not_present(tr)
     end
+
+    test "without rtx" do
+      {:ok, pc} = PeerConnection.start_link(features: [])
+      config = PeerConnection.get_configuration(pc)
+
+      tr =
+        RTPTransceiver.new(:video, @track, config,
+          ssrc: @ssrc,
+          rtx_ssrc: @rtx_ssrc,
+          direction: :sendrecv
+        )
+
+      mline = RTPTransceiver.to_offer_mline(tr, @opts)
+
+      assert [%ExSDP.Attribute.MSID{id: @stream_id}] =
+               ExSDP.get_attributes(mline, ExSDP.Attribute.MSID)
+
+      assert [] = ExSDP.get_attributes(mline, ExSDP.Attribute.SSRCGroup)
+
+      assert [%ExSDP.Attribute.SSRC{id: @ssrc, attribute: "msid", value: @stream_id}] =
+               ExSDP.get_attributes(mline, ExSDP.Attribute.SSRC)
+    end
+
+    test "with rtx" do
+      tr =
+        RTPTransceiver.new(:video, @track, @config,
+          ssrc: @ssrc,
+          rtx_ssrc: @rtx_ssrc,
+          direction: :sendrecv
+        )
+
+      mline = RTPTransceiver.to_offer_mline(tr, @opts)
+
+      assert [
+               %ExSDP.Attribute.MSID{id: @stream_id, app_data: nil}
+             ] = ExSDP.get_attributes(mline, ExSDP.Attribute.MSID)
+
+      assert [
+               %ExSDP.Attribute.SSRCGroup{semantics: "FID", ssrcs: [@ssrc, @rtx_ssrc]}
+             ] = ExSDP.get_attributes(mline, ExSDP.Attribute.SSRCGroup)
+
+      assert [
+               %ExSDP.Attribute.SSRC{id: @ssrc, attribute: "msid", value: @stream_id},
+               %ExSDP.Attribute.SSRC{id: @rtx_ssrc, attribute: "msid", value: @stream_id}
+             ] = ExSDP.get_attributes(mline, ExSDP.Attribute.SSRC)
+    end
+
+    test "without media stream" do
+      track = MediaStreamTrack.new(:video)
+
+      tr =
+        RTPTransceiver.new(:video, track, @config,
+          ssrc: @ssrc,
+          rtx_ssrc: @rtx_ssrc,
+          direction: :sendrecv
+        )
+
+      mline = RTPTransceiver.to_offer_mline(tr, @opts)
+
+      assert [
+               %ExSDP.Attribute.MSID{id: "-", app_data: nil}
+             ] = ExSDP.get_attributes(mline, ExSDP.Attribute.MSID)
+
+      assert [
+               %ExSDP.Attribute.SSRCGroup{semantics: "FID", ssrcs: [@ssrc, @rtx_ssrc]}
+             ] = ExSDP.get_attributes(mline, ExSDP.Attribute.SSRCGroup)
+
+      assert [
+               %ExSDP.Attribute.SSRC{id: @ssrc, attribute: "msid", value: "-"},
+               %ExSDP.Attribute.SSRC{id: @rtx_ssrc, attribute: "msid", value: "-"}
+             ] = ExSDP.get_attributes(mline, ExSDP.Attribute.SSRC)
+    end
+
+    test "with multiple media streams" do
+      s1_id = MediaStreamTrack.generate_stream_id()
+      s2_id = MediaStreamTrack.generate_stream_id()
+
+      track = MediaStreamTrack.new(:video, [s1_id, s2_id])
+
+      tr =
+        RTPTransceiver.new(:video, track, @config,
+          ssrc: @ssrc,
+          rtx_ssrc: @rtx_ssrc,
+          direction: :sendrecv
+        )
+
+      mline = RTPTransceiver.to_offer_mline(tr, @opts)
+
+      assert [
+               %ExSDP.Attribute.MSID{id: ^s1_id, app_data: nil},
+               %ExSDP.Attribute.MSID{id: ^s2_id, app_data: nil}
+             ] = ExSDP.get_attributes(mline, ExSDP.Attribute.MSID)
+
+      assert [
+               %ExSDP.Attribute.SSRCGroup{semantics: "FID", ssrcs: [@ssrc, @rtx_ssrc]}
+             ] = ExSDP.get_attributes(mline, ExSDP.Attribute.SSRCGroup)
+
+      assert [
+               %ExSDP.Attribute.SSRC{id: @ssrc, attribute: "msid", value: ^s1_id},
+               %ExSDP.Attribute.SSRC{id: @ssrc, attribute: "msid", value: ^s2_id},
+               %ExSDP.Attribute.SSRC{id: @rtx_ssrc, attribute: "msid", value: ^s1_id},
+               %ExSDP.Attribute.SSRC{id: @rtx_ssrc, attribute: "msid", value: ^s2_id}
+             ] = ExSDP.get_attributes(mline, ExSDP.Attribute.SSRC)
+    end
+
+    test "without codecs" do
+      {:ok, pc} = PeerConnection.start_link(audio_codecs: [], video_codecs: [])
+      config = PeerConnection.get_configuration(pc)
+
+      tr =
+        RTPTransceiver.new(:video, @track, config,
+          ssrc: @ssrc,
+          rtx_ssrc: @rtx_ssrc,
+          direction: :sendrecv
+        )
+
+      mline = RTPTransceiver.to_offer_mline(tr, @opts)
+
+      assert [%ExSDP.Attribute.MSID{id: @stream_id, app_data: nil}] =
+               ExSDP.get_attributes(mline, ExSDP.Attribute.MSID)
+
+      assert [] = ExSDP.get_attributes(mline, ExSDP.Attribute.SSRCGroup)
+      assert [] = ExSDP.get_attributes(mline, ExSDP.Attribute.SSRC)
+    end
   end
 
   defp test_sender_attrs_present(tr) do
     mline = RTPTransceiver.to_offer_mline(tr, @opts)
 
     # Assert rtp sender attributes are present.
-    # Their exact values are checked in rtp_sender_test.exs.
     assert [%ExSDP.Attribute.MSID{}] = ExSDP.get_attributes(mline, ExSDP.Attribute.MSID)
     assert [%ExSDP.Attribute.SSRCGroup{}] = ExSDP.get_attributes(mline, ExSDP.Attribute.SSRCGroup)
 


### PR DESCRIPTION
This PR allows to set codec that should be used for sending with the following remarks:
* when the first RTP packet is sent, the clock rate used by RTP sender is "locked" meaning that any subsequent call to the `set_sender_codec` must use a codec with the same clock rate. This is because using a new clock rate requires a new SSRC. Also, ReportRecorder, which generates RTCP reports relies on clock rate so changing it after we started sending packets could result in incorrect reports
* when a codec was selected, and as a result of renegotiation it is no longer supported, user must call `set_sender_codec` with a new codec that is supported

It also:
* moves initialization of ReportRecorder so that now, it is initialized when the first packet is sent
* adds checking FMTP parameters  when negotiating codecs (if codec's sdp_fmtp_line is not nil, otherwise sdp_fmtp_line is always assumed to be the same)
* ensures that codec payload types and rtp header extension ids are not changed when they are not used by the remote description (we have been updating them so far even when there was no need to do that)
* sets RTPSender codecs after negotiation (instead of during creation time)

RFC considerations:
* Codecs listed in the remote description are in the preference order i.e. the first codec is the most preferred to receive by the remote side, and we as a sender SHOULD use it for sending.
* However, RFC 3264 (sec 6.1 and 7.0) allows for changing codec on the fly (e.g. during silence periods although Opus solves this problem and I have never seen anyone doing this) and receiver MUST be prepared to handle this situation
* Relying on these requirements, we allow user to set the codec used for sending  
