### PR TITLE
Fix recorder overriding tracks instead of merging on `add_tracks`. Release 0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add `ex_webrtc` to the list of dependencies in `mix.exs`
 ```elixir
 def deps do
   [
-    {:ex_webrtc, "~> 0.8.0"}
+    {:ex_webrtc, "~> 0.8.1"}
   ]
 end
 ```
@@ -29,7 +29,7 @@ adding optional `ex_sctp` dependency
 ```elixir
 def deps do
   [
-    {:ex_webrtc, "~> 0.8.0"},
+    {:ex_webrtc, "~> 0.8.1"},
     {:ex_sctp, "~> 0.1.0"}
   ]
 end

--- a/lib/ex_webrtc/recorder.ex
+++ b/lib/ex_webrtc/recorder.ex
@@ -177,7 +177,7 @@ defmodule ExWebRTC.Recorder do
 
     :ok = File.write!(report_path, Jason.encode!(report))
 
-    %{state | tracks: tracks}
+    state
   end
 
   defp serialize_packet(packet, rid_idx, recv_time) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExWebRTC.MixProject do
   use Mix.Project
 
-  @version "0.8.0"
+  @version "0.8.1"
   @source_url "https://github.com/elixir-webrtc/ex_webrtc"
 
   def project do


### PR DESCRIPTION
Fixes issue outlined in #194

The new tracks were correctly merged into `state` in line 169 but `state` was then erroneously updated again in line 180, causing the freshly added tracks to override the existing ones.