### PR TITLE
Add support for VP8 simulcast

### DIFF
--- a/guides/advanced/simulcast.md
+++ b/guides/advanced/simulcast.md
@@ -86,7 +86,7 @@ This process is known as munging.
 alias ExWebRTC.PeerConnection
 alias ExWebRTC.RTP.{H264, Munger}
 
-m = Munger.new(90_000)
+m = Munger.new(:h264, 90_000)
 ```
 
 2. When a packet from an encoding that we want to forward arrives, rewrite its sequnce number and timestamp:

--- a/lib/ex_webrtc/rtp/vp8.ex
+++ b/lib/ex_webrtc/rtp/vp8.ex
@@ -1,0 +1,26 @@
+defmodule ExWebRTC.RTP.VP8 do
+  @moduledoc """
+  Utilities for RTP packets carrying VP8 encoded payload.
+  """
+
+  alias ExRTP.Packet
+  alias ExWebRTC.RTP.VP8
+
+  @doc """
+  Checks whether RTP payload contains VP8 keyframe.
+  """
+  @spec keyframe?(Packet.t()) :: boolean()
+  def keyframe?(%Packet{payload: rtp_payload}) do
+    # RTP payload contains VP8 keyframe when P bit in VP8 payload header is set to 0
+    # besides this S bit (start of VP8 partition) and PID (partition index)
+    # have to be 1 and 0 respectively
+    # for more information refer to RFC 7741 Sections 4.2 and 4.3
+
+    with {:ok, vp8_payload} <- VP8.Payload.parse(rtp_payload),
+         <<_size0::3, _h::1, _ver::3, p::1, _size1::8, _size2::8, _rest::binary>> <- rtp_payload do
+      vp8_payload.s == 1 and vp8_payload.pid == 0 and p == 0
+    else
+      _err -> false
+    end
+  end
+end

--- a/lib/ex_webrtc/rtp/vp8/munger.ex
+++ b/lib/ex_webrtc/rtp/vp8/munger.ex
@@ -1,0 +1,117 @@
+defmodule ExWebRTC.RTP.VP8.Munger do
+  @moduledoc false
+  # Module responsible for rewriting VP8 RTP payload fields
+  # to provide transparent switch between simulcast encodings.
+  import Bitwise
+
+  alias ExWebRTC.RTP.VP8
+
+  @type t() :: %__MODULE__{
+          pic_id_used: boolean(),
+          last_pic_id: integer(),
+          pic_id_offset: integer(),
+          tl0picidx_used: boolean(),
+          last_tl0picidx: integer(),
+          tl0picidx_offset: integer(),
+          keyidx_used: boolean(),
+          last_keyidx: integer(),
+          keyidx_offset: integer()
+        }
+
+  defstruct pic_id_used: false,
+            last_pic_id: 0,
+            pic_id_offset: 0,
+            tl0picidx_used: false,
+            last_tl0picidx: 0,
+            tl0picidx_offset: 0,
+            keyidx_used: false,
+            last_keyidx: 0,
+            keyidx_offset: 0
+
+  @spec new() :: t()
+  def new() do
+    %__MODULE__{}
+  end
+
+  @spec init(t(), binary()) :: t()
+  def init(vp8_munger, rtp_payload) do
+    {:ok, vp8_payload} = VP8.Payload.parse(rtp_payload)
+
+    last_pic_id = vp8_payload.picture_id || 0
+    last_tl0picidx = vp8_payload.tl0picidx || 0
+    last_keyidx = vp8_payload.keyidx || 0
+
+    %__MODULE__{
+      vp8_munger
+      | pic_id_used: vp8_payload.picture_id != nil,
+        last_pic_id: last_pic_id,
+        tl0picidx_used: vp8_payload.tl0picidx != nil,
+        last_tl0picidx: last_tl0picidx,
+        keyidx_used: vp8_payload.keyidx != nil,
+        last_keyidx: last_keyidx
+    }
+  end
+
+  @spec update(t(), binary()) :: t()
+  def update(vp8_munger, rtp_payload) do
+    {:ok, vp8_payload} = VP8.Payload.parse(rtp_payload)
+
+    %VP8.Payload{
+      keyidx: keyidx,
+      picture_id: pic_id,
+      tl0picidx: tl0picidx
+    } = vp8_payload
+
+    pic_id_offset = (vp8_munger.pic_id_used && pic_id - vp8_munger.last_pic_id - 1) || 0
+
+    tl0picidx_offset =
+      (vp8_munger.tl0picidx_used && tl0picidx - vp8_munger.last_tl0picidx - 1) || 0
+
+    keyidx_offset = (vp8_munger.keyidx_used && keyidx - vp8_munger.last_keyidx - 1) || 0
+
+    %__MODULE__{
+      vp8_munger
+      | pic_id_offset: pic_id_offset,
+        tl0picidx_offset: tl0picidx_offset,
+        keyidx_offset: keyidx_offset
+    }
+  end
+
+  @spec munge(t(), binary()) :: {t(), binary()}
+  def munge(vp8_munger, <<>> = rtp_payload), do: {vp8_munger, rtp_payload}
+
+  def munge(vp8_munger, rtp_payload) do
+    {:ok, vp8_payload} = VP8.Payload.parse(rtp_payload)
+
+    %VP8.Payload{
+      keyidx: keyidx,
+      picture_id: pic_id,
+      tl0picidx: tl0picidx
+    } = vp8_payload
+
+    munged_pic_id = pic_id && rem(pic_id + (1 <<< 15) - vp8_munger.pic_id_offset, 1 <<< 15)
+
+    munged_tl0picidx =
+      tl0picidx && rem(tl0picidx + (1 <<< 8) - vp8_munger.tl0picidx_offset, 1 <<< 8)
+
+    munged_keyidx = keyidx && rem(keyidx + (1 <<< 5) - vp8_munger.keyidx_offset, 1 <<< 5)
+
+    vp8_payload =
+      %VP8.Payload{
+        vp8_payload
+        | keyidx: munged_keyidx,
+          picture_id: munged_pic_id,
+          tl0picidx: munged_tl0picidx
+      }
+      |> VP8.Payload.serialize()
+
+    vp8_munger = %__MODULE__{
+      vp8_munger
+      | last_pic_id: munged_pic_id,
+        last_tl0picidx: munged_tl0picidx,
+        last_keyidx: munged_keyidx
+    }
+
+    {vp8_munger, vp8_payload}
+  end
+end

--- a/test/ex_webrtc/rtp/munger_test.exs
+++ b/test/ex_webrtc/rtp/munger_test.exs
@@ -11,7 +11,7 @@ defmodule ExWebRTC.RTP.MungerTest do
   @packet Packet.new(<<0::128*8>>)
 
   test "assigns sequence numbers properly" do
-    munger = Munger.new(@clock_rate)
+    munger = Munger.new(:h264, @clock_rate)
 
     l1_packet = %{@packet | sequence_number: 100}
     {^l1_packet, munger} = Munger.munge(munger, l1_packet)
@@ -45,7 +45,7 @@ defmodule ExWebRTC.RTP.MungerTest do
   end
 
   test "handles input sequence number rollover" do
-    munger = Munger.new(@clock_rate)
+    munger = Munger.new(:h264, @clock_rate)
 
     l1_packet = %{@packet | sequence_number: 100}
     {^l1_packet, munger} = Munger.munge(munger, l1_packet)
@@ -77,7 +77,7 @@ defmodule ExWebRTC.RTP.MungerTest do
   end
 
   test "handles output sequence number rollover" do
-    munger = Munger.new(@clock_rate)
+    munger = Munger.new(:h264, @clock_rate)
 
     l1_packet = %{@packet | sequence_number: @max_sn - 2}
     {^l1_packet, munger} = Munger.munge(munger, l1_packet)
@@ -98,7 +98,7 @@ defmodule ExWebRTC.RTP.MungerTest do
   end
 
   test "assigns timestamps properly" do
-    munger = Munger.new(@clock_rate)
+    munger = Munger.new(:h264, @clock_rate)
 
     l1_packet = %{@packet | sequence_number: 100, timestamp: 5000}
     {^l1_packet, munger} = Munger.munge(munger, l1_packet)
@@ -134,7 +134,7 @@ defmodule ExWebRTC.RTP.MungerTest do
   end
 
   test "handles input timestamp rollover" do
-    munger = Munger.new(@clock_rate)
+    munger = Munger.new(:h264, @clock_rate)
 
     l1_packet = %{@packet | sequence_number: 100, timestamp: 5000}
     {^l1_packet, munger} = Munger.munge(munger, l1_packet)
@@ -152,7 +152,7 @@ defmodule ExWebRTC.RTP.MungerTest do
   end
 
   test "handles output timestamp rollover" do
-    munger = Munger.new(@clock_rate)
+    munger = Munger.new(:h264, @clock_rate)
 
     l1_packet = %{@packet | sequence_number: 100, timestamp: @max_ts}
     {^l1_packet, munger} = Munger.munge(munger, l1_packet)

--- a/test/ex_webrtc/rtp/vp8/munger_test.exs
+++ b/test/ex_webrtc/rtp/vp8/munger_test.exs
@@ -1,0 +1,200 @@
+defmodule ExWebRTC.RTP.VP8.MungerTest do
+  use ExUnit.Case, async: true
+  import Bitwise
+
+  alias ExWebRTC.RTP.VP8
+
+  test "handles encoding switch properly" do
+    vp8_munger = VP8.Munger.new()
+
+    rtp_payload =
+      %VP8.Payload{
+        keyidx: 28,
+        n: 0,
+        pid: 0,
+        picture_id: 14_617,
+        s: 0,
+        tid: 0,
+        tl0picidx: 19,
+        y: 1,
+        payload: <<0, 1, 2, 3>>
+      }
+      |> VP8.Payload.serialize()
+
+    rtp_payload2 =
+      %VP8.Payload{
+        keyidx: 10,
+        n: 0,
+        pid: 0,
+        picture_id: 11_942,
+        s: 1,
+        tid: 0,
+        tl0picidx: 4,
+        y: 1,
+        payload: <<4, 5, 6, 7>>
+      }
+      |> VP8.Payload.serialize()
+
+    vp8_munger = VP8.Munger.init(vp8_munger, rtp_payload)
+    {vp8_munger, munged_rtp_payload} = VP8.Munger.munge(vp8_munger, rtp_payload)
+
+    # nothing should change
+    assert rtp_payload == munged_rtp_payload
+
+    vp8_munger = VP8.Munger.update(vp8_munger, rtp_payload2)
+    {_vp8_munger, munged_rtp_payload2} = VP8.Munger.munge(vp8_munger, rtp_payload2)
+
+    assert {:ok,
+            %VP8.Payload{
+              keyidx: 29,
+              n: 0,
+              pid: 0,
+              picture_id: 14_618,
+              s: 1,
+              tid: 0,
+              tl0picidx: 20,
+              y: 1
+            }} = VP8.Payload.parse(munged_rtp_payload2)
+  end
+
+  test "handles rollovers properly" do
+    vp8_munger = VP8.Munger.new()
+
+    rtp_payload =
+      %VP8.Payload{
+        # max keyidx
+        keyidx: (1 <<< 5) - 1,
+        n: 0,
+        pid: 0,
+        # max picture id
+        picture_id: (1 <<< 15) - 1,
+        s: 0,
+        tid: 0,
+        # max tl0picidx
+        tl0picidx: (1 <<< 8) - 1,
+        y: 1,
+        payload: <<0, 1, 2, 3>>
+      }
+      |> VP8.Payload.serialize()
+
+    rtp_payload2 =
+      %VP8.Payload{
+        keyidx: 30,
+        n: 0,
+        pid: 0,
+        picture_id: 11_942,
+        s: 1,
+        tid: 0,
+        tl0picidx: 4,
+        y: 1,
+        payload: <<4, 5, 6, 7>>
+      }
+      |> VP8.Payload.serialize()
+
+    vp8_munger = VP8.Munger.init(vp8_munger, rtp_payload)
+    {vp8_munger, munged_rtp_payload} = VP8.Munger.munge(vp8_munger, rtp_payload)
+
+    # nothing should change
+    assert rtp_payload == munged_rtp_payload
+
+    vp8_munger = VP8.Munger.update(vp8_munger, rtp_payload2)
+    {_vp8_munger, munged_rtp_payload2} = VP8.Munger.munge(vp8_munger, rtp_payload2)
+
+    assert {:ok,
+            %VP8.Payload{
+              keyidx: 0,
+              n: 0,
+              pid: 0,
+              picture_id: 0,
+              s: 1,
+              tid: 0,
+              tl0picidx: 0,
+              y: 1
+            }} = VP8.Payload.parse(munged_rtp_payload2)
+  end
+
+  test "doesn't create negative numbers after rollovers" do
+    vp8_munger = VP8.Munger.new()
+
+    rtp_payload =
+      %VP8.Payload{
+        keyidx: 20,
+        n: 0,
+        pid: 0,
+        picture_id: 11_942,
+        s: 1,
+        tid: 0,
+        tl0picidx: 4,
+        y: 1,
+        payload: <<0, 1, 2, 3>>
+      }
+      |> VP8.Payload.serialize()
+
+    rtp_payload2 =
+      %VP8.Payload{
+        # max keyidx
+        keyidx: (1 <<< 5) - 1,
+        n: 0,
+        pid: 0,
+        # max picture id
+        picture_id: (1 <<< 15) - 1,
+        s: 0,
+        tid: 0,
+        # max tl0picidx
+        tl0picidx: (1 <<< 8) - 1,
+        y: 1,
+        payload: <<4, 5, 6, 7>>
+      }
+      |> VP8.Payload.serialize()
+
+    rtp_payload3 =
+      %VP8.Payload{
+        keyidx: 0,
+        n: 0,
+        pid: 0,
+        picture_id: 0,
+        s: 0,
+        tid: 0,
+        tl0picidx: 0,
+        y: 1,
+        payload: <<8, 9, 10, 11>>
+      }
+      |> VP8.Payload.serialize()
+
+    vp8_munger = VP8.Munger.init(vp8_munger, rtp_payload)
+    {vp8_munger, munged_rtp_payload} = VP8.Munger.munge(vp8_munger, rtp_payload)
+
+    # nothing should change
+    assert rtp_payload == munged_rtp_payload
+
+    vp8_munger = VP8.Munger.update(vp8_munger, rtp_payload2)
+    {vp8_munger, munged_rtp_payload2} = VP8.Munger.munge(vp8_munger, rtp_payload2)
+
+    assert {:ok,
+            %VP8.Payload{
+              keyidx: 21,
+              n: 0,
+              pid: 0,
+              picture_id: 11_943,
+              s: 0,
+              tid: 0,
+              tl0picidx: 5,
+              y: 1
+            }} = VP8.Payload.parse(munged_rtp_payload2)
+
+    {_vp8_munger, munged_rtp_payload3} = VP8.Munger.munge(vp8_munger, rtp_payload3)
+
+    # check if picture_id, tl0picidx and keyidx are not negative
+    assert {:ok,
+            %VP8.Payload{
+              keyidx: 22,
+              n: 0,
+              pid: 0,
+              picture_id: 11_944,
+              s: 0,
+              tid: 0,
+              tl0picidx: 6,
+              y: 1
+            }} = VP8.Payload.parse(munged_rtp_payload3)
+  end
+end


### PR DESCRIPTION
This PR moves and adjusts VP8 simulcast code from [Membrane RTC Engine](https://github.com/fishjam-dev/membrane_rtc_engine/blob/master/webrtc/lib/webrtc/vp8_munger.ex)