### PR TITLE
feat: Add `data_type` configuration to `PeerConnection.send_data`

### DIFF
--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -245,9 +245,9 @@ defmodule ExWebRTC.PeerConnection do
 
   If `ref` does not identify any DataChannel, this function behaves like no-op.
   """
-  @spec send_data(peer_connection(), DataChannel.ref(), binary()) :: :ok
-  def send_data(peer_connection, channel_ref, data) do
-    GenServer.cast(peer_connection, {:send_data, channel_ref, data})
+  @spec send_data(peer_connection(), DataChannel.ref(), binary(), :string | :binary) :: :ok
+  def send_data(peer_connection, channel_ref, data, data_type \\ :string) do
+    GenServer.cast(peer_connection, {:send_data, channel_ref, data_type, data})
   end
 
   @doc """
@@ -1265,10 +1265,9 @@ defmodule ExWebRTC.PeerConnection do
   end
 
   @impl true
-  def handle_cast({:send_data, channel_ref, data}, state) do
-    # TODO: allow for configuring the type of data
+  def handle_cast({:send_data, channel_ref, data_type, data}, state) do
     {events, sctp_transport} =
-      SCTPTransport.send(state.sctp_transport, channel_ref, :string, data)
+      SCTPTransport.send(state.sctp_transport, channel_ref, data_type, data)
 
     handle_sctp_events(events, state)
 

--- a/test/ex_webrtc/data_channel_test.exs
+++ b/test/ex_webrtc/data_channel_test.exs
@@ -180,6 +180,19 @@ defmodule ExWebRTC.DataChannelTest do
       assert_receive {:ex_webrtc, ^pc1, {:data, ^ref1, ^data2}}
     end
 
+    test "as binary", %{pc1: pc1, pc2: pc2, ref1: ref1, ref2: ref2} do
+      data1 = <<1, 2, 3>>
+      :ok = PeerConnection.send_data(pc1, ref1, data1, :binary)
+      assert_receive {:ex_webrtc, ^pc2, {:data, ^ref2, ^data1}}
+
+      data2 = for i <- 1..2000, into: <<>>, do: <<i>>
+      :ok = PeerConnection.send_data(pc1, ref1, data2, :binary)
+      assert_receive {:ex_webrtc, ^pc2, {:data, ^ref2, ^data2}}
+
+      :ok = PeerConnection.send_data(pc1, ref1, <<>>, :binary)
+      assert_receive {:ex_webrtc, ^pc2, {:data, ^ref2, <<>>}}
+    end
+
     test "back and forth", %{pc1: pc1, pc2: pc2, ref1: ref1, ref2: ref2} do
       data = for i <- 1..1024, into: <<>>, do: <<i>>
       :ok = PeerConnection.send_data(pc2, ref2, data)


### PR DESCRIPTION
- Added a parameter to the `PeerConnection.send_data` function to allow for the choice between `:binary` and `:string`.
- Added a simple test to verify the new `PeerConnection.send_data/4` arity.

No tests were added to validate the correctness of the payload, as it's handled by [ex_sctp](https://github.com/elixir-webrtc/ex_sctp) and would require some sort of passthrough mock. Please let me know if this would require testing and what the preferred approach would be.