### PR TITLE
Accept padded DataChannelAck, fix closing DataChannel

### DIFF
--- a/lib/ex_webrtc/sctp_transport.ex
+++ b/lib/ex_webrtc/sctp_transport.ex
@@ -279,7 +279,7 @@ if Code.ensure_loaded?(ExSCTP) do
 
           ExSCTP.close_stream(sctp_transport.ref, id)
 
-          case Enum.find_value(sctp_transport.channels, fn {_k, v} -> v.id == id end) do
+          case Enum.find(sctp_transport.channels, fn {_k, v} -> v.id == id end) do
             {ref, %DataChannel{}} ->
               channels = Map.delete(sctp_transport.channels, ref)
               stats = Map.delete(sctp_transport.stats, ref)

--- a/lib/ex_webrtc/sctp_transport/dcep.ex
+++ b/lib/ex_webrtc/sctp_transport/dcep.ex
@@ -8,6 +8,8 @@ defmodule ExWebRTC.SCTPTransport.DCEP do
     defstruct []
 
     def decode(<<>>), do: {:ok, %__MODULE__{}}
+    # Some implementations (e.g. Pion) seems to pad DataChannelAck to 4 bytes. Accept them.
+    def decode(<<_, _, _>>), do: {:ok, %__MODULE__{}}
     def decode(_other), do: :error
 
     def encode(%__MODULE__{}), do: <<0x02>>


### PR DESCRIPTION
Pion seems to pad DataChannelAck to 4 bytes: https://github.com/pion/datachannel/blob/master/message_channel_ack.go#L10