### PR TITLE
Look for SPS instead of keyframe with H264 packetization_mode=0

### DIFF
--- a/lib/ex_webrtc/rtp/h264.ex
+++ b/lib/ex_webrtc/rtp/h264.ex
@@ -7,10 +7,16 @@ defmodule ExWebRTC.RTP.H264 do
 
   # Copied nearly 1-to-1 from https://github.com/membraneframework/membrane_rtp_h264_plugin/blob/master/lib/rtp_h264/utils.ex
   # originally based on galene's implementation https://github.com/jech/galene/blob/6fbdf0eab2c9640e673d9f9ec0331da24cbf2c4c/codecs/codecs.go#L119
-  # but only looks for SPS
-  # it is also unclear why we sometimes check against nalu type == 7
-  # and sometimes against nalu type == 5 but galene does it this way
-  # and it works
+  # but only looks for SPS, in packetization_mode=0 as well as packetization_mode=1.
+  #
+  # It's been empirically tested with simulated packet loss that for packetization_mode=0 (`nalu_type in 1..23` clause):
+  # * if we're checking against `nalu_type == 5`, the stream breaks regularly when switching layers,
+  # * if we're checking against `nalu_type == 5 or nalu_type == 7`, the stream breaks occasionally when switching layers,
+  #   this happens when we've lost the packet containing SPS, but received the following one containing the keyframe,
+  # * if we're checking against `nalu_type == 7`, no issues were encountered.
+  #
+  # Janus also does it this way.
+  # https://github.com/meetecho/janus-gateway/blob/3367f41de9225daed812ca0991c259f1458fe49f/src/utils.h#L352
 
   @doc """
   Returns a boolean telling if the packets contains a beginning of a H264 intra-frame.
@@ -22,7 +28,7 @@ defmodule ExWebRTC.RTP.H264 do
   def keyframe?(%Packet{}), do: false
 
   defp do_keyframe?(0, _), do: false
-  defp do_keyframe?(nalu_type, _) when nalu_type in 1..23, do: nalu_type == 5
+  defp do_keyframe?(nalu_type, _) when nalu_type in 1..23, do: nalu_type == 7
   defp do_keyframe?(24, aus), do: check_aggr_units(24, aus)
 
   defp do_keyframe?(nalu_type, <<_don::16, aus::binary>>)


### PR DESCRIPTION
As explained in the comments, checking for `nalu_type == 7` with H264 packetization_mode=0 has been verified to work correctly under simulated packet loss conditions.