### PR TITLE
bugfix/dtls-crash-onclose

### DIFF
--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -1391,7 +1391,11 @@ defmodule ExWebRTC.PeerConnection do
     Logger.debug("Closing peer connection")
     transceivers = Enum.map(state.transceivers, &RTPTransceiver.stop(&1))
     sctp_transport = SCTPTransport.close_abruptly(state.sctp_transport)
-    :ok = DTLSTransport.close(state.dtls_transport)
+
+    if state.dtls_transport do
+      :ok = DTLSTransport.close(state.dtls_transport)
+    end
+
     :ok = state.ice_transport.close(state.ice_pid)
 
     state =


### PR DESCRIPTION
- the strange behaviour occured randomly when my peer tried to close its connection
- this fix dtls_transport = nil causing peer connection crashes when closed
- already try catch `PeerConnection.close()`. but still cannot avoid this error because its nif  implementation (?)
- this pr eliminate my current workaround by checking `PeerConnection.get_dtls_transport_state(peer_connection) not in [:failed, :closed]` before closing peer connection

<img width="1835" height="388" alt="image" src="https://github.com/user-attachments/assets/ef44dbbc-0c41-41db-9192-fbf5ca695ebc" />
