### PR TITLE
Add instructions for static IP to fly guide

### DIFF
--- a/guides/deploying/fly.md
+++ b/guides/deploying/fly.md
@@ -2,11 +2,12 @@
 
 Elixir WebRTC-based apps can be easily deployed on [Fly.io](https://fly.io)!
 
-There are just three things you need to do:
+There are just four things you need to do:
 
 * configure a STUN server both on the client and server side
 * use a custom Fly.io IP filter on the server side
 * slightly modify the auto-generated Dockerfile 
+* ensure you have a static IP
 
 In JavaScript code:
 
@@ -55,7 +56,8 @@ Now:
     +     && apt-get clean && rm -f /var/lib/apt/lists/*_*
     ```
 
-3. Run `fly deploy` to retry.
+3. Follow instructions [here](https://fly.io/docs/networking/udp-and-tcp/#you-need-a-dedicated-ipv4-address) to add a dedicated IPv4 address.
+4. Run `fly deploy` to retry.
 
 That's it!
-No special UDP port exports or dedicated IP address are needed :)
+No special UDP port exports are needed :)


### PR DESCRIPTION
I have just spent the morning getting ex_webrtc running on a fly instance. The instructions claim that a static IP isn't necessary, but it didn't work for me until I added the static IP. Fly's [documentation](https://fly.io/docs/networking/udp-and-tcp/#you-need-a-dedicated-ipv4-address) says you do need a static IP to make this work.

It's possible I'm missing something. I know webrtc has a fallback to TCP, so perhaps that's what's missing here, but that wasn't working with the Fly IP filter, in any case.

If I'm missing something, please let me know, and I can prepare an alternative PR that includes some additional explanation as to how this is intended to work.

Thanks!

(Love this project, by the way. We are going to be able to do some cool things thanks to ex_webrtc!)