### PR TITLE
fix: skip RTCP sends when connection is closed or failed

### DIFF
--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -1680,6 +1680,11 @@ defmodule ExWebRTC.PeerConnection do
   end
 
   @impl true
+  def handle_info(:send_twcc_feedback, %{conn_state: conn_state} = state)
+      when conn_state in [:failed, :closed],
+      do: {:noreply, state}
+
+  @impl true
   def handle_info(:send_twcc_feedback, %{twcc_recorder: twcc_recorder} = state) do
     Process.send_after(self(), :send_twcc_feedback, @twcc_interval)
 
@@ -1696,6 +1701,11 @@ defmodule ExWebRTC.PeerConnection do
       {:noreply, state}
     end
   end
+
+  @impl true
+  def handle_info({:send_reports, _transceiver_id}, %{conn_state: conn_state} = state)
+      when conn_state in [:failed, :closed],
+      do: {:noreply, state}
 
   @impl true
   def handle_info({:send_reports, transceiver_id}, state) do
@@ -1722,6 +1732,11 @@ defmodule ExWebRTC.PeerConnection do
 
     {:noreply, %{state | transceivers: transceivers}}
   end
+
+  @impl true
+  def handle_info({:send_nacks, _transceiver_id}, %{conn_state: conn_state} = state)
+      when conn_state in [:failed, :closed],
+      do: {:noreply, state}
 
   @impl true
   def handle_info({:send_nacks, transceiver_id}, state) do


### PR DESCRIPTION
## Problem

After calling `PeerConnection.close/1`, the TWCC feedback, sender/receiver report, and NACK timers continue to fire because they are self-rescheduling and their already-queued mailbox messages cannot be cancelled. Each fired message attempts to call `DTLSTransport.send_rtcp/2`, which logs a debug warning since DTLS is no longer connected:

```
Attempted to send RTCP in wrong DTLS state: closed. Ignoring.
```

This is a race condition between the DTLS/ICE teardown completing and in-flight timer messages being processed. Fixes #232.

## Solution

Add guard clauses before each of the three affected `handle_info` handlers to short-circuit when `conn_state` is `:closed` or `:failed`. This matches the existing pattern already used by the `send_rtp` cast handler:

```elixir
def handle_cast({:send_rtp, track_id, packet, opts}, %{conn_state: conn_state} = state)
    when conn_state not in [:failed, :closed] do
```

The three new guard clauses follow the same convention:

```elixir
def handle_info(:send_twcc_feedback, %{conn_state: conn_state} = state)
    when conn_state in [:failed, :closed],
    do: {:noreply, state}

def handle_info({:send_reports, _transceiver_id}, %{conn_state: conn_state} = state)
    when conn_state in [:failed, :closed],
    do: {:noreply, state}

def handle_info({:send_nacks, _transceiver_id}, %{conn_state: conn_state} = state)
    when conn_state in [:failed, :closed],
    do: {:noreply, state}
```

## Testing

Manually verified by starting a WebRTC stream, stopping it, and confirming the debug message no longer appears in logs.