### PR TITLE
[FCE-3227] Fix DTLS fingerprint not being validated in certain cases

### DIFF
--- a/lib/ex_webrtc/dtls_transport.ex
+++ b/lib/ex_webrtc/dtls_transport.ex
@@ -481,34 +481,10 @@ defmodule ExWebRTC.DTLSTransport do
         {:ok, state}
 
       {:handshake_finished, lkm, rkm, profile, packets} ->
-        Logger.debug("DTLS handshake finished")
-        state = update_remote_cert_info(state)
-        :ok = do_send(state, packets)
-
-        peer_fingerprint =
-          state.dtls
-          |> ExDTLS.get_peer_cert()
-          |> ExDTLS.get_cert_fingerprint()
-          |> Utils.hex_dump()
-
-        if peer_fingerprint == state.peer_fingerprint do
-          :ok = setup_srtp(state, lkm, rkm, profile)
-          state = update_dtls_state(state, :connected)
-          state = flush_buffered_remote_rtp_packets(state)
-          {:ok, state}
-        else
-          Logger.debug("Non-matching peer cert fingerprint.")
-          state = update_dtls_state(state, :failed)
-          {:ok, state}
-        end
+        handle_handshake_finished(state, lkm, rkm, profile, packets)
 
       {:handshake_finished, lkm, rkm, profile} ->
-        Logger.debug("DTLS handshake finished")
-        :ok = setup_srtp(state, lkm, rkm, profile)
-        state = update_dtls_state(state, :connected)
-        state = flush_buffered_remote_rtp_packets(state)
-        state = update_remote_cert_info(state)
-        {:ok, state}
+        handle_handshake_finished(state, lkm, rkm, profile)
 
       :handshake_want_read ->
         {:ok, state}
@@ -552,6 +528,33 @@ defmodule ExWebRTC.DTLSTransport do
 
     state = %{state | buffered_remote_rtp_packets: [data | state.buffered_remote_rtp_packets]}
     {:ok, state}
+  end
+
+  defp handle_handshake_finished(state, lkm, rkm, profile, packets \\ []) do
+    Logger.debug("DTLS handshake finished")
+
+    if peer_fingerprint_matching?(state) do
+      :ok = setup_srtp(state, lkm, rkm, profile)
+      state = update_dtls_state(state, :connected)
+      state = flush_buffered_remote_rtp_packets(state)
+      state = update_remote_cert_info(state)
+      :ok = do_send(state, packets)
+      {:ok, state}
+    else
+      Logger.debug("Non-matching peer cert fingerprint.")
+      state = update_dtls_state(state, :failed)
+      {:ok, state}
+    end
+  end
+
+  defp peer_fingerprint_matching?(%{peer_fingerprint: expected_fp} = state) do
+    actual_fp =
+      state.dtls
+      |> ExDTLS.get_peer_cert()
+      |> ExDTLS.get_cert_fingerprint()
+      |> Utils.hex_dump()
+
+    expected_fp == actual_fp
   end
 
   defp setup_srtp(state, local_keying_material, remote_keying_material, profile) do

--- a/test/ex_webrtc/dtls_transport_test.exs
+++ b/test/ex_webrtc/dtls_transport_test.exs
@@ -163,8 +163,15 @@ defmodule ExWebRTC.DTLSTransportTest do
     ice_transport: ice_transport,
     ice_pid: ice_pid
   } do
-    :ok = DTLSTransport.start_dtls(dtls, :active, @fingerprint)
     remote_dtls = ExDTLS.init(mode: :server, dtls_srtp: true)
+
+    remote_fingerprint =
+      remote_dtls
+      |> ExDTLS.get_cert()
+      |> ExDTLS.get_cert_fingerprint()
+      |> Utils.hex_dump()
+
+    :ok = DTLSTransport.start_dtls(dtls, :active, remote_fingerprint)
     :ok = DTLSTransport.set_ice_connected(dtls)
 
     # perform DTLS-SRTP handshake
@@ -240,9 +247,15 @@ defmodule ExWebRTC.DTLSTransportTest do
     ice_transport: ice_transport,
     ice_pid: ice_pid
   } do
-    :ok = DTLSTransport.start_dtls(dtls, :active, @fingerprint)
     remote_dtls = ExDTLS.init(mode: :server, dtls_srtp: true)
 
+    remote_fingerprint =
+      remote_dtls
+      |> ExDTLS.get_cert()
+      |> ExDTLS.get_cert_fingerprint()
+      |> Utils.hex_dump()
+
+    :ok = DTLSTransport.start_dtls(dtls, :active, remote_fingerprint)
     :ok = DTLSTransport.set_ice_connected(dtls)
 
     assert {:ok, _, _, _} = check_handshake(dtls, ice_transport, ice_pid, remote_dtls)
@@ -296,9 +309,15 @@ defmodule ExWebRTC.DTLSTransportTest do
     ice_transport: ice_transport,
     ice_pid: ice_pid
   } do
-    :ok = DTLSTransport.start_dtls(dtls, :active, @fingerprint)
     remote_dtls = ExDTLS.init(mode: :server, dtls_srtp: true)
 
+    remote_fingerprint =
+      remote_dtls
+      |> ExDTLS.get_cert()
+      |> ExDTLS.get_cert_fingerprint()
+      |> Utils.hex_dump()
+
+    :ok = DTLSTransport.start_dtls(dtls, :active, remote_fingerprint)
     :ok = DTLSTransport.set_ice_connected(dtls)
 
     assert {:ok, _, _, _} = check_handshake(dtls, ice_transport, ice_pid, remote_dtls)
@@ -328,9 +347,15 @@ defmodule ExWebRTC.DTLSTransportTest do
     ice_transport: ice_transport,
     ice_pid: ice_pid
   } do
-    :ok = DTLSTransport.start_dtls(dtls, :active, @fingerprint)
     remote_dtls = ExDTLS.init(mode: :server, dtls_srtp: true)
 
+    remote_fingerprint =
+      remote_dtls
+      |> ExDTLS.get_cert()
+      |> ExDTLS.get_cert_fingerprint()
+      |> Utils.hex_dump()
+
+    :ok = DTLSTransport.start_dtls(dtls, :active, remote_fingerprint)
     :ok = DTLSTransport.set_ice_connected(dtls)
 
     # perform DTLS-SRTP handshake
@@ -380,9 +405,15 @@ defmodule ExWebRTC.DTLSTransportTest do
     ice_transport: ice_transport,
     ice_pid: ice_pid
   } do
-    :ok = DTLSTransport.start_dtls(dtls, :active, @fingerprint)
     remote_dtls = ExDTLS.init(mode: :server, dtls_srtp: true)
 
+    remote_fingerprint =
+      remote_dtls
+      |> ExDTLS.get_cert()
+      |> ExDTLS.get_cert_fingerprint()
+      |> Utils.hex_dump()
+
+    :ok = DTLSTransport.start_dtls(dtls, :active, remote_fingerprint)
     :ok = DTLSTransport.set_ice_connected(dtls)
 
     # perform DTLS-SRTP handshake


### PR DESCRIPTION
**This is a bugfix for a vulnerability found by @songxpu**

As stated in the issue #249, when `ExDTLS` returned `:handshake_finished` with no packets, the actual peer fingerprint was not validated to match the one passed in the SDP offer/answer. Skipping this check is presumed to allow man-in-the-middle attacks which hijack the DTLS key exchange process and could therefore compromise the E2E encryption of the media being sent.

After this PR is merged, I recommend:
- creating bugfix releases for the two most recent minor releases: `0.15.1`, `0.16.1`
- retiring releases `0.15.0`, `0.16.0`
- informing the community about this vulnerability and the extent we believe it could be (or have been) exploited

Additional research is needed to confirm the severity of this vulnerability, which was reported as **critical**