### PR TITLE
Handle invalid retransmit timeout from ExDTLS

### DIFF
--- a/lib/ex_webrtc/dtls_transport.ex
+++ b/lib/ex_webrtc/dtls_transport.ex
@@ -177,7 +177,7 @@ defmodule ExWebRTC.DTLSTransport do
 
     if state.mode == :active do
       {:ok, packets, timeout} = ExDTLS.do_handshake(state.dtls)
-      Process.send_after(self(), :dtls_timeout, timeout)
+      arm_dtls_timer(timeout)
       :ok = do_send(state, packets)
       state = update_dtls_state(state, :connecting)
       Logger.debug("Started DTLS handshake")
@@ -385,20 +385,20 @@ defmodule ExWebRTC.DTLSTransport do
       {:retransmit, packets, timeout} when state.ice_connected ->
         :ok = do_send(state, packets)
         Logger.debug("Retransmitted DTLS packets")
-        Process.send_after(self(), :dtls_timeout, timeout)
+        arm_dtls_timer(timeout)
 
       {:retransmit, ^buffered_local_packets, timeout} ->
         # we got DTLS packets from the other side but
         # we haven't established ICE connection yet so
         # packets to retransmit have to be the same as dtls_buffered_packets
-        Process.send_after(self(), :dtls_timeout, timeout)
+        arm_dtls_timer(timeout)
 
       {:retransmit, _packets, timeout} ->
         Logger.warning(
           "DTLSTransport: Packets to retransmit differ from buffered local packets despite ICE not being connected"
         )
 
-        Process.send_after(self(), :dtls_timeout, timeout)
+        arm_dtls_timer(timeout)
 
       :ok ->
         :ok
@@ -465,7 +465,7 @@ defmodule ExWebRTC.DTLSTransport do
     case ExDTLS.handle_data(state.dtls, data) do
       {:handshake_packets, packets, timeout} when state.ice_connected ->
         :ok = do_send(state, packets)
-        Process.send_after(self(), :dtls_timeout, timeout)
+        arm_dtls_timer(timeout)
         state = update_dtls_state(state, :connecting)
         {:ok, state}
 
@@ -475,7 +475,7 @@ defmodule ExWebRTC.DTLSTransport do
         We will send those packets once ICE is ready.
         """)
 
-        Process.send_after(self(), :dtls_timeout, timeout)
+        arm_dtls_timer(timeout)
         state = %{state | buffered_local_packets: packets}
         state = update_dtls_state(state, :connecting)
         {:ok, state}
@@ -626,6 +626,20 @@ defmodule ExWebRTC.DTLSTransport do
         mode: nil
     }
     |> update_dtls_state(:closed, opts)
+  end
+
+  @doc false
+  @spec arm_dtls_timer(term()) :: reference()
+  def arm_dtls_timer(timeout) when is_integer(timeout) and timeout >= 0 do
+    Process.send_after(self(), :dtls_timeout, timeout)
+  end
+
+  def arm_dtls_timer(timeout) do
+    Logger.warning(
+      "ExDTLS returned invalid retransmit timeout: #{inspect(timeout)}; clamping to 0"
+    )
+
+    Process.send_after(self(), :dtls_timeout, 0)
   end
 
   defp do_send(state, data) when is_list(data) do

--- a/test/ex_webrtc/dtls_transport_test.exs
+++ b/test/ex_webrtc/dtls_transport_test.exs
@@ -485,6 +485,20 @@ defmodule ExWebRTC.DTLSTransportTest do
     assert false == Process.alive?(dtls)
   end
 
+  describe "arm_dtls_timer/1" do
+    test "schedules :dtls_timeout for a valid non-negative timeout" do
+      assert is_reference(DTLSTransport.arm_dtls_timer(20))
+      assert_receive :dtls_timeout, 200
+    end
+
+    test "does not crash on invalid timeout values" do
+      for bad <- [-1, nil, :infinity, 1.5, "100"] do
+        assert is_reference(DTLSTransport.arm_dtls_timer(bad))
+        assert_receive :dtls_timeout, 100
+      end
+    end
+  end
+
   defp setup_srtp(lkm, rkm, profile) do
     in_srtp = ExLibSRTP.new()
     out_srtp = ExLibSRTP.new()


### PR DESCRIPTION
```
RTC Engine endpoint Membrane.RTC.Engine.Endpoint.ExWebRTC:"8f9a6e6b-b4ca-4ec8-957e-a53467469d55" crashed: {:membrane_child_crash, :connection_handler, {:timeout_value, [{:gen_server, :loop, 5, [file: ~c"gen_server.erl", line: 2311]}, {ExDTLS, :handle_data, 2, [file: ~c"lib/ex_dtls.ex", line: 178]}, {ExWebRTC.DTLSTransport, :handle_ice_data, 2, [file: ~c"lib/ex_webrtc/dtls_transport.ex", line: 465]}, {ExWebRTC.DTLSTransport, :handle_info, 2, [file: ~c"lib/ex_webrtc/dtls_transport.ex", line: 412]}, {:gen_server, :try_handle_info, 3, [file: ~c"gen_server.erl", line: 2434]}, {:gen_server, :handle_msg, 3, [file: ~c"gen_server.erl", line: 2420]}, {:proc_lib, :init_p_do_apply, 3, [file: ~c"proc_lib.erl", line: 333]}]}}
```
Basically, ExDTLS can sometimes return an invalid timeout (nil, negative integer). This PR implements a guard around `Process.send_after`.