### PR TITLE
[FCE-2939] Add TWCC send log

### DIFF
--- a/lib/ex_webrtc/peer_connection.ex
+++ b/lib/ex_webrtc/peer_connection.ex
@@ -10,7 +10,7 @@ defmodule ExWebRTC.PeerConnection do
   require Logger
 
   alias ExWebRTC.RTPCodecParameters
-  alias __MODULE__.{Configuration, Demuxer, TWCCRecorder}
+  alias __MODULE__.{Configuration, Demuxer, TWCCRecvLog, TWCCSendLog}
 
   alias ExWebRTC.{
     DataChannel,
@@ -88,7 +88,8 @@ defmodule ExWebRTC.PeerConnection do
   is not used.
   * each of the packets in `:rtcp` message is in the form of `{track_id, packet}` tuple, where `track_id` is the id of the corrsponding track.
   In case of PLI and NACK, this is the id of an outgoing (sender's) track id, in case of Sender and Receiver Reports - incoming (receiver's) track id.
-  If matching to a track was not possible (like in the case of TWCC packedts), `track_id` is set to `nil`.
+  If matching to a track was not possible (like in the case of TWCC packets), `track_id` is set to `nil`.
+  To correlate TWCC feedback with departure times of outgoing packets, use `get_twcc_departure_log/1`.
   """
   @type message() ::
           {:ex_webrtc, pid(),
@@ -276,6 +277,25 @@ defmodule ExWebRTC.PeerConnection do
   @spec set_packet_loss(peer_connection(), 0..100) :: :ok | {:error, term()}
   def set_packet_loss(peer_connection, value) when value in 0..100 do
     GenServer.cast(peer_connection, {:set_packet_loss, value})
+  end
+
+  @doc """
+  Returns the TWCC departure log for outgoing RTP packets.
+
+  The log maps 16-bit TWCC sequence numbers to `{departure_time, size}` tuples, where
+  `departure_time` is in microseconds (from `System.monotonic_time/1`) and `size` is
+  the packet size in bytes (pre-SRTP).
+
+  Use this to correlate incoming TWCC feedback (`ExRTCP.Packet.TransportFeedback.CC`)
+  received via `{:rtcp, ...}` notifications with the departure times of the reported packets.
+
+  The log is bounded by a 2-second sliding window and entries expire automatically.
+  """
+  @spec get_twcc_departure_log(peer_connection()) :: %{
+          non_neg_integer() => {departure_time :: integer(), size :: non_neg_integer()}
+        }
+  def get_twcc_departure_log(peer_connection) do
+    GenServer.call(peer_connection, :get_twcc_departure_log)
   end
 
   #### MDN-API ####
@@ -668,7 +688,8 @@ defmodule ExWebRTC.PeerConnection do
       peer_fingerprint: nil,
       sent_packets: 0,
       twcc_extension_id: twcc_id,
-      twcc_recorder: TWCCRecorder.new()
+      twcc_recv_log: TWCCRecvLog.new(),
+      twcc_send_log: TWCCSendLog.new()
     }
 
     notify(state.owner, {:connection_state_change, :new})
@@ -754,6 +775,11 @@ defmodule ExWebRTC.PeerConnection do
   @impl true
   def handle_call(:get_signaling_state, _from, state) do
     {:reply, state.signaling_state, state}
+  end
+
+  @impl true
+  def handle_call(:get_twcc_departure_log, _from, state) do
+    {:reply, TWCCSendLog.to_map(state.twcc_send_log), state}
   end
 
   @impl true
@@ -1445,28 +1471,42 @@ defmodule ExWebRTC.PeerConnection do
         # Remove these extensions and add ours.
         packet = ExRTP.Packet.remove_extensions(packet)
 
-        {packet, state} =
+        {packet, twcc_seq_no, state} =
           case state.twcc_extension_id do
             nil ->
-              {packet, state}
+              {packet, nil, state}
 
             id ->
+              seq_no = state.sent_packets
+
               twcc =
-                ExRTP.Packet.Extension.TWCC.new(state.sent_packets)
+                ExRTP.Packet.Extension.TWCC.new(seq_no)
                 |> ExRTP.Packet.Extension.TWCC.to_raw(id)
 
               packet = ExRTP.Packet.add_extension(packet, twcc)
 
               state = %{state | sent_packets: state.sent_packets + 1 &&& 0xFFFF}
-              {packet, state}
+              {packet, seq_no, state}
           end
 
         {packet, tr} = RTPTransceiver.send_packet(tr, packet, rtx?)
 
         if packet != <<>>, do: :ok = DTLSTransport.send_rtp(state.dtls_transport, packet)
 
+        twcc_send_log =
+          if twcc_seq_no != nil and packet != <<>> do
+            TWCCSendLog.record_packet(
+              state.twcc_send_log,
+              twcc_seq_no,
+              System.monotonic_time(:microsecond),
+              byte_size(packet)
+            )
+          else
+            state.twcc_send_log
+          end
+
         transceivers = List.replace_at(state.transceivers, idx, tr)
-        state = %{state | transceivers: transceivers}
+        state = %{state | transceivers: transceivers, twcc_send_log: twcc_send_log}
 
         {:noreply, state}
 
@@ -1601,20 +1641,20 @@ defmodule ExWebRTC.PeerConnection do
          {idx, t} <- find_transceiver(state.transceivers, mid) do
       # id == nil means we either did not negotiate TWCC, or it was turned off
 
-      twcc_recorder =
+      twcc_recv_log =
         with id when id != nil <- state.twcc_extension_id,
              {:ok, raw_ext} <- ExRTP.Packet.fetch_extension(packet, id),
              {:ok, %{sequence_number: seq_no}} <- ExRTP.Packet.Extension.TWCC.from_raw(raw_ext) do
           # we always update the ssrc's for the one's from the latest packet
           # although this is not a necessity, the feedbacks are transport-wide
-          %TWCCRecorder{
-            state.twcc_recorder
+          %TWCCRecvLog{
+            state.twcc_recv_log
             | media_ssrc: packet.ssrc,
               sender_ssrc: t.sender.ssrc
           }
-          |> TWCCRecorder.record_packet(seq_no)
+          |> TWCCRecvLog.record_packet(seq_no)
         else
-          _other -> state.twcc_recorder
+          _other -> state.twcc_recv_log
         end
 
       transceivers =
@@ -1631,7 +1671,7 @@ defmodule ExWebRTC.PeerConnection do
         state
         | demuxer: demuxer,
           transceivers: transceivers,
-          twcc_recorder: twcc_recorder
+          twcc_recv_log: twcc_recv_log
       }
 
       {:noreply, state}
@@ -1681,18 +1721,18 @@ defmodule ExWebRTC.PeerConnection do
   end
 
   @impl true
-  def handle_info(:send_twcc_feedback, %{twcc_recorder: twcc_recorder} = state) do
+  def handle_info(:send_twcc_feedback, %{twcc_recv_log: twcc_recv_log} = state) do
     Process.send_after(self(), :send_twcc_feedback, @twcc_interval)
 
-    if twcc_recorder.media_ssrc != nil do
-      {feedbacks, twcc_recorder} = TWCCRecorder.get_feedback(twcc_recorder)
+    if twcc_recv_log.media_ssrc != nil do
+      {feedbacks, twcc_recv_log} = TWCCRecvLog.get_feedback(twcc_recv_log)
 
       for feedback <- feedbacks do
         encoded = ExRTCP.Packet.encode(feedback)
         :ok = DTLSTransport.send_rtcp(state.dtls_transport, encoded)
       end
 
-      {:noreply, %{state | twcc_recorder: twcc_recorder}}
+      {:noreply, %{state | twcc_recv_log: twcc_recv_log}}
     else
       {:noreply, state}
     end

--- a/lib/ex_webrtc/peer_connection/twcc_recv_log.ex
+++ b/lib/ex_webrtc/peer_connection/twcc_recv_log.ex
@@ -1,6 +1,11 @@
-defmodule ExWebRTC.PeerConnection.TWCCRecorder do
+defmodule ExWebRTC.PeerConnection.TWCCRecvLog do
   @moduledoc false
-  # inspired by Pion's TWCC interceptor https://github.com/pion/interceptor/tree/master/pkg/twcc
+  # Receiver-side TWCC log.
+  # Records arrival timestamps for incoming RTP packets that carry a TWCC
+  # sequence number, then generates TransportFeedback.CC (TWCC) RTCP packets
+  # to report those timestamps back to the sender.
+  #
+  # Inspired by Pion's TWCC interceptor https://github.com/pion/interceptor/tree/master/pkg/twcc
   # and chrome's implementation https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/modules/remote_bitrate_estimator/remote_estimator_proxy.cc;l=276;drc=b5cd13bb6d5d157a5fbe3628b2dd1c1e106203c6;bpv=0
 
   defmodule Timer do

--- a/lib/ex_webrtc/peer_connection/twcc_send_log.ex
+++ b/lib/ex_webrtc/peer_connection/twcc_send_log.ex
@@ -1,0 +1,39 @@
+defmodule ExWebRTC.PeerConnection.TWCCSendLog do
+  @moduledoc false
+  # Sender-side TWCC log.
+  # Records departure timestamps and sizes for outgoing RTP packets
+  # that carry a TWCC sequence number, allowing the end user to correlate
+  # incoming TWCC feedback (TransportFeedback.CC) with send times.
+
+  @packet_window_us 2_000_000
+
+  @type t() :: %__MODULE__{
+          packets: %{non_neg_integer() => {integer(), non_neg_integer()}}
+        }
+
+  defstruct packets: %{}
+
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @spec record_packet(t(), non_neg_integer(), integer(), non_neg_integer()) :: t()
+  def record_packet(log, seq_no, departure_time, size) do
+    packets =
+      log.packets
+      |> Map.put(seq_no, {departure_time, size})
+      |> remove_old_packets(departure_time)
+
+    %__MODULE__{log | packets: packets}
+  end
+
+  @spec to_map(t()) :: %{non_neg_integer() => {integer(), non_neg_integer()}}
+  def to_map(%__MODULE__{packets: packets}), do: packets
+
+  defp remove_old_packets(packets, current_time) do
+    min_time = current_time - @packet_window_us
+
+    Map.filter(packets, fn {_seq_no, {departure_time, _size}} ->
+      departure_time >= min_time
+    end)
+  end
+end

--- a/lib/ex_webrtc/peer_connection/twcc_send_log.ex
+++ b/lib/ex_webrtc/peer_connection/twcc_send_log.ex
@@ -8,32 +8,43 @@ defmodule ExWebRTC.PeerConnection.TWCCSendLog do
   @packet_window_us 2_000_000
 
   @type t() :: %__MODULE__{
-          packets: %{non_neg_integer() => {integer(), non_neg_integer()}}
+          packets: %{non_neg_integer() => {integer(), non_neg_integer()}},
+          seq_no_queue: Qex.t()
         }
 
-  defstruct packets: %{}
+  defstruct packets: %{}, seq_no_queue: Qex.new()
 
   @spec new() :: t()
   def new, do: %__MODULE__{}
 
   @spec record_packet(t(), non_neg_integer(), integer(), non_neg_integer()) :: t()
   def record_packet(log, seq_no, departure_time, size) do
-    packets =
-      log.packets
-      |> Map.put(seq_no, {departure_time, size})
-      |> remove_old_packets(departure_time)
+    seq_no_queue = Qex.push(log.seq_no_queue, {seq_no, departure_time})
+    packets = Map.put(log.packets, seq_no, {departure_time, size})
 
-    %__MODULE__{log | packets: packets}
+    {seq_no_queue, packets} = remove_old_packets(packets, seq_no_queue, departure_time)
+
+    %__MODULE__{log | packets: packets, seq_no_queue: seq_no_queue}
   end
 
   @spec to_map(t()) :: %{non_neg_integer() => {integer(), non_neg_integer()}}
   def to_map(%__MODULE__{packets: packets}), do: packets
 
-  defp remove_old_packets(packets, current_time) do
+  defp remove_old_packets(packets, seq_no_queue, current_time) do
     min_time = current_time - @packet_window_us
 
-    Map.filter(packets, fn {_seq_no, {departure_time, _size}} ->
-      departure_time >= min_time
-    end)
+    Enum.reduce_while(
+      seq_no_queue,
+      {seq_no_queue, packets},
+      fn {seq_no, dep_time}, {seq_no_queue, packets} = acc ->
+        if dep_time < min_time do
+          {_, seq_no_queue} = Qex.pop!(seq_no_queue)
+          packets = Map.delete(packets, seq_no)
+          {:cont, {seq_no_queue, packets}}
+        else
+          {:halt, acc}
+        end
+      end
+    )
   end
 end

--- a/test/ex_webrtc/peer_connection/twcc_recv_log_test.exs
+++ b/test/ex_webrtc/peer_connection/twcc_recv_log_test.exs
@@ -1,20 +1,20 @@
-defmodule ExWebRTC.PeerConnection.TWCCRecorderTest do
+defmodule ExWebRTC.PeerConnection.TWCCRecvLogTest do
   use ExUnit.Case, async: true
 
   alias ExRTCP.Packet.TransportFeedback.CC
-  alias ExWebRTC.PeerConnection.TWCCRecorder
+  alias ExWebRTC.PeerConnection.TWCCRecvLog
 
   @max_seq_no 0xFFFF
   @seq_no 541
 
-  @recorder TWCCRecorder.new(1, 2)
+  @recorder TWCCRecvLog.new(1, 2)
 
   describe "record_packet/2" do
     test "initial case" do
-      recorder = TWCCRecorder.record_packet(@recorder, @seq_no)
+      recorder = TWCCRecvLog.record_packet(@recorder, @seq_no)
       end_seq_no = @seq_no + 1
 
-      assert %TWCCRecorder{
+      assert %TWCCRecvLog{
                timestamps: %{@seq_no => _timestamp},
                base_seq_no: @seq_no,
                start_seq_no: @seq_no,
@@ -26,14 +26,14 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorderTest do
       seq_no_2 = @seq_no + 1
       seq_no_3 = @seq_no + 2
 
-      recorder = TWCCRecorder.record_packet(@recorder, @seq_no)
+      recorder = TWCCRecvLog.record_packet(@recorder, @seq_no)
       Process.sleep(1)
-      recorder = TWCCRecorder.record_packet(recorder, seq_no_2)
+      recorder = TWCCRecvLog.record_packet(recorder, seq_no_2)
       Process.sleep(1)
-      recorder = TWCCRecorder.record_packet(recorder, seq_no_3)
+      recorder = TWCCRecvLog.record_packet(recorder, seq_no_3)
       end_seq_no = @seq_no + 3
 
-      assert %TWCCRecorder{
+      assert %TWCCRecvLog{
                timestamps: %{
                  @seq_no => timestamp_1,
                  ^seq_no_2 => timestamp_2,
@@ -52,15 +52,15 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorderTest do
       seq_no_2 = @seq_no + 5
       seq_no_3 = @seq_no + 3
 
-      recorder = TWCCRecorder.record_packet(@recorder, @seq_no)
+      recorder = TWCCRecvLog.record_packet(@recorder, @seq_no)
       Process.sleep(15)
-      recorder = TWCCRecorder.record_packet(recorder, seq_no_2)
+      recorder = TWCCRecvLog.record_packet(recorder, seq_no_2)
       Process.sleep(15)
-      recorder = TWCCRecorder.record_packet(recorder, seq_no_3)
+      recorder = TWCCRecvLog.record_packet(recorder, seq_no_3)
 
       end_seq_no = @seq_no + 6
 
-      assert %TWCCRecorder{
+      assert %TWCCRecvLog{
                timestamps: %{
                  @seq_no => timestamp_1,
                  ^seq_no_2 => timestamp_2,
@@ -87,17 +87,17 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorderTest do
 
       recorder =
         @recorder
-        |> TWCCRecorder.record_packet(seq_no_2)
-        |> TWCCRecorder.record_packet(seq_no_1)
-        |> TWCCRecorder.record_packet(seq_no_5 - @max_seq_no - 1)
-        |> TWCCRecorder.record_packet(seq_no_4)
-        |> TWCCRecorder.record_packet(seq_no_6 - @max_seq_no - 1)
-        |> TWCCRecorder.record_packet(seq_no_3)
-        |> TWCCRecorder.record_packet(seq_no_7 - @max_seq_no - 1)
+        |> TWCCRecvLog.record_packet(seq_no_2)
+        |> TWCCRecvLog.record_packet(seq_no_1)
+        |> TWCCRecvLog.record_packet(seq_no_5 - @max_seq_no - 1)
+        |> TWCCRecvLog.record_packet(seq_no_4)
+        |> TWCCRecvLog.record_packet(seq_no_6 - @max_seq_no - 1)
+        |> TWCCRecvLog.record_packet(seq_no_3)
+        |> TWCCRecvLog.record_packet(seq_no_7 - @max_seq_no - 1)
 
       end_seq_no = seq_no_7 + 1
 
-      assert %TWCCRecorder{
+      assert %TWCCRecvLog{
                timestamps: %{
                  ^seq_no_1 => _,
                  ^seq_no_2 => _,
@@ -123,12 +123,12 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorderTest do
 
       recorder =
         @recorder
-        |> TWCCRecorder.record_packet(@seq_no)
-        |> TWCCRecorder.record_packet(seq_no_2)
+        |> TWCCRecvLog.record_packet(@seq_no)
+        |> TWCCRecvLog.record_packet(seq_no_2)
 
       end_seq_no = seq_no_2 + 1
 
-      assert %TWCCRecorder{
+      assert %TWCCRecvLog{
                base_seq_no: @seq_no,
                start_seq_no: @seq_no,
                end_seq_no: ^end_seq_no,
@@ -141,14 +141,14 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorderTest do
 
       recorder =
         recorder
-        |> TWCCRecorder.record_packet(seq_no_3)
-        |> TWCCRecorder.record_packet(seq_no_4)
-        |> TWCCRecorder.record_packet(seq_no_5)
+        |> TWCCRecvLog.record_packet(seq_no_3)
+        |> TWCCRecvLog.record_packet(seq_no_4)
+        |> TWCCRecvLog.record_packet(seq_no_5)
 
       start_seq_no = seq_no_2 + 1
       end_seq_no = seq_no_5 + 1
 
-      assert %TWCCRecorder{
+      assert %TWCCRecvLog{
                base_seq_no: ^start_seq_no,
                start_seq_no: ^start_seq_no,
                end_seq_no: ^end_seq_no,
@@ -161,13 +161,13 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorderTest do
 
       recorder =
         recorder
-        |> TWCCRecorder.record_packet(seq_no_6)
-        |> TWCCRecorder.record_packet(seq_no_7)
+        |> TWCCRecvLog.record_packet(seq_no_6)
+        |> TWCCRecvLog.record_packet(seq_no_7)
 
       start_seq_no = seq_no_5 + 1
       end_seq_no = seq_no_7 + 1
 
-      assert %TWCCRecorder{
+      assert %TWCCRecvLog{
                base_seq_no: ^start_seq_no,
                start_seq_no: ^start_seq_no,
                end_seq_no: ^end_seq_no,
@@ -189,7 +189,7 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorderTest do
         (@seq_no + 3) => base_ts + 32
       }
 
-      recorder = %TWCCRecorder{
+      recorder = %TWCCRecvLog{
         @recorder
         | base_seq_no: @seq_no,
           start_seq_no: @seq_no,
@@ -197,7 +197,7 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorderTest do
           timestamps: timestamps
       }
 
-      assert {[feedback], recorder} = TWCCRecorder.get_feedback(recorder)
+      assert {[feedback], recorder} = TWCCRecvLog.get_feedback(recorder)
 
       assert %CC{
                base_sequence_number: @seq_no,
@@ -209,7 +209,7 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorderTest do
              } = feedback
 
       # no new packets -> no feedback
-      assert {[], _recorder} = TWCCRecorder.get_feedback(recorder)
+      assert {[], _recorder} = TWCCRecvLog.get_feedback(recorder)
     end
 
     test "packets out of order, with gaps" do
@@ -223,7 +223,7 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorderTest do
         (@seq_no + 5) => base_ts + 25
       }
 
-      recorder = %TWCCRecorder{
+      recorder = %TWCCRecvLog{
         @recorder
         | base_seq_no: @seq_no,
           start_seq_no: @seq_no,
@@ -231,7 +231,7 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorderTest do
           timestamps: timestamps
       }
 
-      assert {[feedback], recorder} = TWCCRecorder.get_feedback(recorder)
+      assert {[feedback], recorder} = TWCCRecvLog.get_feedback(recorder)
 
       symbols = [
         :small_delta,
@@ -252,21 +252,21 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorderTest do
                recv_deltas: [246, 5, -17, -8, 25]
              } = feedback
 
-      assert {[], _recorder} = TWCCRecorder.get_feedback(recorder)
+      assert {[], _recorder} = TWCCRecvLog.get_feedback(recorder)
     end
 
     test "mixed chunks" do
       end_no = 634
       packet_num = end_no - @seq_no + 1
 
-      recorder = TWCCRecorder.record_packet(@recorder, @seq_no)
+      recorder = TWCCRecvLog.record_packet(@recorder, @seq_no)
 
       recorder =
         Enum.reduce((@seq_no + 2)..end_no, recorder, fn i, recorder ->
-          TWCCRecorder.record_packet(recorder, i)
+          TWCCRecvLog.record_packet(recorder, i)
         end)
 
-      assert {[feedback], recorder} = TWCCRecorder.get_feedback(recorder)
+      assert {[feedback], recorder} = TWCCRecvLog.get_feedback(recorder)
 
       assert %CC{
                base_sequence_number: @seq_no,
@@ -288,22 +288,22 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorderTest do
 
       assert length(deltas) == packet_num - 1
 
-      assert {[], _recorder} = TWCCRecorder.get_feedback(recorder)
+      assert {[], _recorder} = TWCCRecvLog.get_feedback(recorder)
     end
 
     test "split into two feedbacks" do
       recorder =
         @recorder
-        |> TWCCRecorder.record_packet(@seq_no)
-        |> TWCCRecorder.record_packet(@seq_no + 1)
-        |> TWCCRecorder.record_packet(@seq_no + 2)
+        |> TWCCRecvLog.record_packet(@seq_no)
+        |> TWCCRecvLog.record_packet(@seq_no + 1)
+        |> TWCCRecvLog.record_packet(@seq_no + 2)
 
       # simulate huge delta between 3rd and 4th packet
       base_no2 = @seq_no + 2
       timestamps = Map.update!(recorder.timestamps, base_no2, &(&1 + 35_000))
       recorder = %{recorder | timestamps: timestamps}
 
-      assert {[feedback1, feedback2], recorder} = TWCCRecorder.get_feedback(recorder)
+      assert {[feedback1, feedback2], recorder} = TWCCRecvLog.get_feedback(recorder)
 
       assert %CC{
                base_sequence_number: @seq_no,
@@ -327,7 +327,7 @@ defmodule ExWebRTC.PeerConnection.TWCCRecorderTest do
       refute_in_delta ref_time1, ref_time2, 133
       assert_in_delta ref_time1, ref_time2, 143
 
-      assert {[], _recorder} = TWCCRecorder.get_feedback(recorder)
+      assert {[], _recorder} = TWCCRecvLog.get_feedback(recorder)
     end
   end
 end

--- a/test/ex_webrtc/peer_connection/twcc_send_log_test.exs
+++ b/test/ex_webrtc/peer_connection/twcc_send_log_test.exs
@@ -1,0 +1,107 @@
+defmodule ExWebRTC.PeerConnection.TWCCSendLogTest do
+  use ExUnit.Case, async: true
+
+  alias ExWebRTC.PeerConnection.TWCCSendLog
+
+  @seq_no 100
+  @size 1200
+
+  describe "new/0" do
+    test "creates empty log" do
+      log = TWCCSendLog.new()
+      assert TWCCSendLog.to_map(log) == %{}
+    end
+  end
+
+  describe "record_packet/4" do
+    test "records a single packet" do
+      now = System.monotonic_time(:microsecond)
+      log = TWCCSendLog.new() |> TWCCSendLog.record_packet(@seq_no, now, @size)
+
+      assert TWCCSendLog.to_map(log) == %{@seq_no => {now, @size}}
+    end
+
+    test "records multiple sequential packets" do
+      now = System.monotonic_time(:microsecond)
+
+      log =
+        TWCCSendLog.new()
+        |> TWCCSendLog.record_packet(@seq_no, now, @size)
+        |> TWCCSendLog.record_packet(@seq_no + 1, now + 1000, @size)
+        |> TWCCSendLog.record_packet(@seq_no + 2, now + 2000, @size)
+
+      map = TWCCSendLog.to_map(log)
+
+      assert map_size(map) == 3
+      assert map[@seq_no] == {now, @size}
+      assert map[@seq_no + 1] == {now + 1000, @size}
+      assert map[@seq_no + 2] == {now + 2000, @size}
+    end
+
+    test "records packets with different sizes" do
+      now = System.monotonic_time(:microsecond)
+
+      log =
+        TWCCSendLog.new()
+        |> TWCCSendLog.record_packet(@seq_no, now, 100)
+        |> TWCCSendLog.record_packet(@seq_no + 1, now + 1000, 500)
+
+      map = TWCCSendLog.to_map(log)
+
+      assert map[@seq_no] == {now, 100}
+      assert map[@seq_no + 1] == {now + 1000, 500}
+    end
+  end
+
+  describe "eviction" do
+    test "evicts packets older than 2 seconds" do
+      old_time = System.monotonic_time(:microsecond) - 3_000_000
+      now = System.monotonic_time(:microsecond)
+
+      log =
+        TWCCSendLog.new()
+        |> TWCCSendLog.record_packet(@seq_no, old_time, @size)
+        |> TWCCSendLog.record_packet(@seq_no + 1, old_time + 100, @size)
+        |> TWCCSendLog.record_packet(@seq_no + 2, now, @size)
+
+      map = TWCCSendLog.to_map(log)
+
+      refute Map.has_key?(map, @seq_no)
+      refute Map.has_key?(map, @seq_no + 1)
+      assert Map.has_key?(map, @seq_no + 2)
+    end
+
+    test "keeps packets within the 2-second window" do
+      now = System.monotonic_time(:microsecond)
+
+      log =
+        TWCCSendLog.new()
+        |> TWCCSendLog.record_packet(@seq_no, now - 1_500_000, @size)
+        |> TWCCSendLog.record_packet(@seq_no + 1, now, @size)
+
+      map = TWCCSendLog.to_map(log)
+      assert map_size(map) == 2
+    end
+  end
+
+  describe "seq_no wrapping" do
+    test "handles 16-bit seq_no values near the boundary" do
+      now = System.monotonic_time(:microsecond)
+
+      log =
+        TWCCSendLog.new()
+        |> TWCCSendLog.record_packet(0xFFFE, now, @size)
+        |> TWCCSendLog.record_packet(0xFFFF, now + 1000, @size)
+        |> TWCCSendLog.record_packet(0, now + 2000, @size)
+        |> TWCCSendLog.record_packet(1, now + 3000, @size)
+
+      map = TWCCSendLog.to_map(log)
+
+      assert map_size(map) == 4
+      assert map[0xFFFE] == {now, @size}
+      assert map[0xFFFF] == {now + 1000, @size}
+      assert map[0] == {now + 2000, @size}
+      assert map[1] == {now + 3000, @size}
+    end
+  end
+end


### PR DESCRIPTION
Add TWCC send log for outgoing packet departure tracking

- Introduce TWCCSendLog to record departure timestamps and sizes of outgoing RTP packets carrying TWCC sequence numbers, bounded by a 2-second sliding window
- Expose `get_twcc_departure_log/1` public API so users can correlate incoming TWCC feedback with send times for bandwidth estimation
- Rename TWCCRecorder to TWCCRecvLog for clarity, distinguishing receiver-side (arrival) from sender-side (departure) logging

ref: https://github.com/fishjam-cloud/sfu/pull/66